### PR TITLE
fix get_activity, and replace : in paths for Windows

### DIFF
--- a/garminexport/backup.py
+++ b/garminexport/backup.py
@@ -45,10 +45,11 @@ def export_filename(activity, export_format):
     :return: The file name to use for the exported activity.
     :rtype: str
     """
-    return "{time}_{id}{suffix}".format(
+    fn = "{time}_{id}{suffix}".format(
         id=activity[0],
         time=activity[1].isoformat(), 
         suffix=format_suffix[export_format])   
+    return fn.replace(':','_') if os.name=='nt' else fn
 
 
 def need_backup(activities, backup_dir, export_formats=None):

--- a/garminexport/garminclient.py
+++ b/garminexport/garminclient.py
@@ -11,7 +11,8 @@ import requests
 from StringIO import StringIO
 import sys
 import zipfile
-import dateutil
+import dateutil.parser
+from functools import wraps
 
 #
 # Note: For more detailed information about the API services
@@ -38,6 +39,7 @@ def require_session(client_function):
     """Decorator that is used to annotate :class:`GarminClient`
     methods that need an authenticated session before being called.
     """
+    @wraps(client_function)
     def check_session(*args, **kwargs):
         client_object = args[0]
         if not client_object.session:
@@ -269,6 +271,7 @@ class GarminClient(object):
         return response.text
 
 
+    @require_session
     def get_activity_tcx(self, activity_id):
         """Return a TCX (Training Center XML) representation of a
         given activity. If the activity doesn't have a TCX source (for


### PR DESCRIPTION
Looks like `get_activity.py` fell out of sync with changes in the library. Also, Windows doesn't like `:` in paths, so I made `export_filename` replace 'em with `_` on Windows.