### PR TITLE
Update endpoint for get_activity_details, fixes #27

### DIFF
--- a/garminexport/garminclient.py
+++ b/garminexport/garminclient.py
@@ -245,8 +245,8 @@ class GarminClient(object):
         :returns: The activity details as a JSON dict.
         :rtype: dict
         """
-        # mounted at xml or json depending on result encoding
-        response = self.session.get("https://connect.garmin.com/modern/proxy/activity-service-1.3/json/activityDetails/{}".format(activity_id))
+        # returns json if no Accept: header is explicitly sent
+        response = self.session.get("https://connect.garmin.com/modern/proxy/activity-service/json/activity/{}/details".format(activity_id))
         if response.status_code != 200:
             raise Exception(u"failed to fetch json activityDetails for {}: {}\n{}".format(
                 activity_id, response.status_code, response.text))


### PR DESCRIPTION
The endpoint moved, this is the new URL. It looks like this code should probably be sending `Accept: application/json` headers throughout, but it's not really required as Garmin Connect seems to return JSON responses by default anyway.