### PR TITLE
Relax dependency version to use compatible releases

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-requests==2.21.0
-python-dateutil==2.4.1
-future==0.16.0
+requests~=2.21.0
+python-dateutil~=2.4.1
+future~=0.16.0
 
-nose==1.3.7
-coverage==4.2
-mock==2.0.0
+nose~=1.3.7
+coverage~=4.2
+mock~=2.0.0


### PR DESCRIPTION
I am trying to use garminexport as a library and the pinned down dependencies make it incompatible with pandas which asks for dateutil >= 2.5.0.

As far as I can tell, relaxing the dependency versions required to be compatible should't do any harm.