### PR TITLE
Fix documentation error

### DIFF
--- a/garminbackup.py
+++ b/garminbackup.py
@@ -22,7 +22,7 @@ if __name__ == "__main__":
         incremental_backup(username=args.username,
                            password=args.password,
                            backup_dir=args.backup_dir,
-                           format=args.format,
+                           export_formats=args.format,
                            ignore_errors=args.ignore_errors,
                            max_retries=args.max_retries)
 

--- a/garminexport/backup.py
+++ b/garminexport/backup.py
@@ -8,7 +8,7 @@ from datetime import datetime
 
 log = logging.getLogger(__name__)
 
-export_formats = ["json_summary", "json_details", "gpx", "tcx", "fit"]
+supported_export_formats = ["json_summary", "json_details", "gpx", "tcx", "fit"]
 """The range of supported export formats for activities."""
 
 format_suffix = {

--- a/garminexport/cli.py
+++ b/garminexport/cli.py
@@ -1,7 +1,7 @@
 import argparse
 import os
 
-from garminexport.backup import export_formats
+from garminexport.backup import supported_export_formats
 
 DEFAULT_MAX_RETRIES = 7
 """The default maximum number of retries to make when fetching a single activity."""
@@ -34,9 +34,9 @@ def parse_args() -> argparse.Namespace:
         help="Desired log output level (DEBUG, INFO, WARNING, ERROR). Default: INFO.",
         default="INFO")
     parser.add_argument(
-        "-f", "--format", choices=export_formats,
+        "-f", "--format", choices=supported_export_formats,
         default=None, action='append',
-        help="Desired output formats ({}). Default: ALL.".format(', '.join(export_formats)))
+        help="Desired output formats ({}). Default: ALL.".format(', '.join(supported_export_formats)))
     parser.add_argument(
         "-E", "--ignore-errors", action='store_true',
         help="Ignore errors and keep going. Default: FALSE")

--- a/garminexport/incremental_backup.py
+++ b/garminexport/incremental_backup.py
@@ -5,7 +5,7 @@ import os
 from datetime import timedelta
 
 import garminexport.backup
-from garminexport.backup import export_formats
+from garminexport.backup import supported_export_formats
 from garminexport.garminclient import GarminClient
 from garminexport.retryer import Retryer, ExponentialBackoffDelayStrategy, MaxRetriesStopStrategy
 
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 def incremental_backup(username: str,
                        password: str = None,
                        backup_dir: str = os.path.join(".", "activities"),
-                       format: str = 'ALL',
+                       export_formats: str = 'ALL',
                        ignore_errors: bool = False,
                        max_retries: int = 7):
     """Performs (incremental) backups of activities for a given Garmin Connect account.
@@ -23,7 +23,7 @@ def incremental_backup(username: str,
     :param username: Garmin Connect user name
     :param password: Garmin Connect user password. Default: None. If not provided, would be asked interactively.
     :param backup_dir: Destination directory for downloaded activities. Default: ./activities/".
-    :param format: Desired output formats (json_summary, json_details, gpx, tcx, fit). Default: ALL.
+    :param export_formats: Desired output formats (json_summary, json_details, gpx, tcx, fit). Default: ALL.
     :param ignore_errors: Ignore errors and keep going. Default: False.
     :param max_retries: The maximum number of retries to make on failed attempts to fetch an activity.
     Exponential backoff will be used, meaning that the delay between successive attempts
@@ -34,8 +34,8 @@ def incremental_backup(username: str,
     stored in the backup directory will be downloaded.
     """
     # if no --format was specified, all formats are to be backed up
-    format = format if format else export_formats
-    log.info("backing up formats: %s", ", ".join(format))
+    export_formats = export_formats if export_formats else supported_export_formats
+    log.info("backing up formats: %s", ", ".join(export_formats))
 
     if not os.path.isdir(backup_dir):
         os.makedirs(backup_dir)
@@ -54,7 +54,7 @@ def incremental_backup(username: str,
         activities = set(retryer.call(client.list_activities))
         log.info("account has a total of %d activities", len(activities))
 
-        missing_activities = garminexport.backup.need_backup(activities, backup_dir, format)
+        missing_activities = garminexport.backup.need_backup(activities, backup_dir, export_formats)
         backed_up = activities - missing_activities
         log.info("%s contains %d backed up activities", backup_dir, len(backed_up))
 
@@ -62,11 +62,11 @@ def incremental_backup(username: str,
 
         for index, activity in enumerate(missing_activities):
             id, start = activity
-            log.info("backing up activity %s from %s (%d out of %d) ...",
-                     id, start, index + 1, len(missing_activities))
+            log.info("backing up activity %d from %s (%d out of %d) ..." % (
+                id, start, index + 1, len(missing_activities)))
             try:
-                garminexport.backup.download(client, activity, retryer, backup_dir, format)
+                garminexport.backup.download(client, activity, retryer, backup_dir, export_formats)
             except Exception as e:
-                log.error("failed with exception: %s", e)
+                log.error(u"failed with exception: %s", e)
                 if not ignore_errors:
                     raise

--- a/get_activity.py
+++ b/get_activity.py
@@ -30,7 +30,7 @@ if __name__ == "__main__":
         "activity", metavar="<activity>", type=int, help="Activity ID.")
     parser.add_argument(
         "format", metavar="<format>", type=str,
-        help="Export format (one of: {}).".format(garminexport.backup.export_formats))
+        help="Export format (one of: {}).".format(garminexport.backup.supported_export_formats))
 
     # optional args
     parser.add_argument(
@@ -49,10 +49,10 @@ if __name__ == "__main__":
     if args.log_level not in LOG_LEVELS:
         raise ValueError("Illegal log-level argument: {}".format(args.log_level))
 
-    if args.format not in garminexport.backup.export_formats:
+    if args.format not in garminexport.backup.supported_export_formats:
         raise ValueError(
             "Unrecognized export format: '{}'. Must be one of {}".format(
-                args.format, garminexport.backup.export_formats))
+                args.format, garminexport.backup.supported_export_formats))
 
     logging.root.setLevel(LOG_LEVELS[args.log_level])
 


### PR DESCRIPTION
Fix the error in documentation. Format argument should have been a list of strings, not a string.