### PR TITLE
Added kml download functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ Supported export formats:
       format, mainly for storing GPS routes/tracks. It does support extensions
       and Garmin appears to annotate the GPS data with, for example, heart-rate
       and cadence, when available on your device.</sub>
+      
+  -   `kml`: activity KML file (Google Earth).
+
+      <sub>[KML](https://en.wikipedia.org/wiki/Keyhole_Markup_Language) is an XML
+      formatted file for annotating and visualizing maps with Google Earth.</sub>
 
   -   `tcx`: an activity TCX file (XML).
       *Note: a `.tcx` file may not always be possible to export, for example

--- a/garminexport/backup.py
+++ b/garminexport/backup.py
@@ -8,13 +8,14 @@ from datetime import datetime
 
 log = logging.getLogger(__name__)
 
-supported_export_formats = ["json_summary", "json_details", "gpx", "tcx", "fit"]
+supported_export_formats = ["json_summary", "json_details", "gpx", "kml", "tcx", "fit"]
 """The range of supported export formats for activities."""
 
 format_suffix = {
     "json_summary": "_summary.json",
     "json_details": "_details.json",
     "gpx": ".gpx",
+    "kml": ".kml",
     "tcx": ".tcx",
     "fit": ".fit"
 }
@@ -64,7 +65,7 @@ def need_backup(activities, backup_dir, export_formats=None):
     :param backup_dir: Destination directory for exported activities.
     :type backup_dir: str
     :keyword export_formats: Which format(s) to export to. Could be any
-      of: 'json_summary', 'json_details', 'gpx', 'tcx', 'fit'.
+      of: 'json_summary', 'json_details', 'gpx', 'kml', 'tcx', 'fit'.
     :type export_formats: list of str
     :return: All activities that need to be backed up.
     :rtype: set of tuples of `(int, datetime)`
@@ -111,7 +112,7 @@ def download(client, activity, retryer, backup_dir, export_formats=None):
     :param backup_dir: Backup directory path (assumed to exist already).
     :type backup_dir: str
     :keyword export_formats: Which format(s) to export to. Could be any
-      of: 'json_summary', 'json_details', 'gpx', 'tcx', 'fit'.
+      of: 'json_summary', 'json_details', 'gpx', 'kml', 'tcx', 'fit'.
     :type export_formats: list of str
     """
     id = activity[0]
@@ -143,6 +144,16 @@ def download(client, activity, retryer, backup_dir, export_formats=None):
             else:
                 with codecs.open(dest, encoding="utf-8", mode="w") as f:
                     f.write(activity_gpx)
+
+        if 'kml' in export_formats:
+            log.debug("getting kml for %s", id)
+            activity_kml = retryer.call(client.get_activity_kml, id)
+            dest = os.path.join(backup_dir, export_filename(activity, 'kml'))
+            if activity_kml is None:
+                not_found.write(os.path.basename(dest) + "\n")
+            else:
+                with codecs.open(dest, encoding="utf-8", mode="w") as f:
+                    f.write(activity_kml)
 
         if 'tcx' in export_formats:
             log.debug("getting tcx for %s", id)

--- a/garminexport/garminclient.py
+++ b/garminexport/garminclient.py
@@ -278,6 +278,31 @@ class GarminClient(object):
         return response.text
 
     @require_session
+    def get_activity_kml(self, activity_id):
+        """Return a KML (Keyhole Markup Language) representation of a
+        given activity. If the activity cannot be exported to KML
+        (not yet observed in practice, but that doesn't exclude the
+        possibility), a :obj:`None` value is returned.
+
+        :param activity_id: Activity identifier.
+        :type activity_id: int
+        :returns: The KML representation of the activity as an KML string
+          or ``None`` if the activity couldn't be exported to KML.
+        :rtype: str
+        """
+        response = self.session.get(
+            "https://connect.garmin.com/modern/proxy/download-service/export/kml/activity/{}".format(activity_id))
+        # A 404 (Not Found) or 204 (No Content) response are both indicators
+        # of a kml file not being available for the activity. It may, for
+        # example be a manually entered activity without any device data.
+        if response.status_code in (404, 204):
+            return None
+        if response.status_code != 200:
+            raise Exception(u"failed to fetch KML for activity {}: {}\n{}".format(
+                activity_id, response.status_code, response.text))
+        return response.text
+
+    @require_session
     def get_activity_tcx(self, activity_id):
         """Return a TCX (Training Center XML) representation of a
         given activity. If the activity doesn't have a TCX source (for
@@ -375,7 +400,7 @@ class GarminClient(object):
         fn = os.path.basename(file.name)
         _, ext = os.path.splitext(fn)
         if format is None:
-            if ext.lower() in ('.gpx', '.tcx', '.fit'):
+            if ext.lower() in ('.gpx', '.kml', '.tcx', '.fit'):
                 format = ext.lower()[1:]
             else:
                 raise Exception(u"could not guess file type for {}".format(fn))

--- a/garminexport/incremental_backup.py
+++ b/garminexport/incremental_backup.py
@@ -3,7 +3,6 @@ import getpass
 import logging
 import os
 from datetime import timedelta
-from typing import List
 
 import garminexport.backup
 from garminexport.backup import supported_export_formats
@@ -16,7 +15,7 @@ log = logging.getLogger(__name__)
 def incremental_backup(username: str,
                        password: str = None,
                        backup_dir: str = os.path.join(".", "activities"),
-                       export_formats: List[str] = None,
+                       export_formats: str = 'ALL',
                        ignore_errors: bool = False,
                        max_retries: int = 7):
     """Performs (incremental) backups of activities for a given Garmin Connect account.
@@ -24,8 +23,7 @@ def incremental_backup(username: str,
     :param username: Garmin Connect user name
     :param password: Garmin Connect user password. Default: None. If not provided, would be asked interactively.
     :param backup_dir: Destination directory for downloaded activities. Default: ./activities/".
-    :param export_formats: List of desired output formats (json_summary, json_details, gpx, tcx, fit).
-    Default: `None` which means all supported formats will be backed up.
+    :param export_formats: Desired output formats (json_summary, json_details, gpx, kml, tcx, fit). Default: ALL.
     :param ignore_errors: Ignore errors and keep going. Default: False.
     :param max_retries: The maximum number of retries to make on failed attempts to fetch an activity.
     Exponential backoff will be used, meaning that the delay between successive attempts


### PR DESCRIPTION
1. Added kml extension to `supported_export_formats` and `format_suffix` in backup.py
2. Add kml format to `download()` function in backup.py
3. Added `def get_activity_kml()` function in garminclient.py
4. Updated doc string for `incremental_backup()` in incremental_backup.py to include kml
5. Updated README.md