### PR TITLE
Fix setting the activity name as the description

### DIFF
--- a/garminexport/garminclient.py
+++ b/garminexport/garminclient.py
@@ -407,7 +407,7 @@ class GarminClient(object):
         if name is not None:
             data['activityName'] = name
         if description is not None:
-            data['description'] = name
+            data['description'] = description
         if activity_type is not None:
             data['activityTypeDTO'] = {"typeKey": activity_type}
         if private:


### PR DESCRIPTION
Currently when a description is supplied for an uploaded activity, the name is used instead. This commit fixes this oversight.