### PR TITLE
Adapt to new fit file names in downloaded zip

### DIFF
--- a/garminexport/garminclient.py
+++ b/garminexport/garminclient.py
@@ -335,7 +335,7 @@ class GarminClient(object):
         zip_file = zipfile.ZipFile(BytesIO(response.content), mode="r")
         for path in zip_file.namelist():
             fn, ext = os.path.splitext(path)
-            if fn == str(activity_id):
+            if fn.startswith(str(activity_id)):
                 return ext[1:], zip_file.open(path).read()
         return None, None
 


### PR DESCRIPTION
For original file downloads we do now get a zip
file with a fit file named {activity_id}_ACTIVITY.fit.
This breaks the current assumption and fails to extract
the fit file.

Fix #61 by relaxing the file name comparison.