### PR TITLE
Specify number of activities to request in list_activities()

### DIFF
--- a/garminexport/garminclient.py
+++ b/garminexport/garminclient.py
@@ -154,18 +154,22 @@ class GarminClient(object):
         return auth_ticket_url
 
     @require_session
-    def list_activities(self):
-        """Return all activity ids stored by the logged in user, along
+    def list_activities(self, request_size=sys.maxsize):
+        """Return activity ids stored by the logged in user, along
         with their starting timestamps.
 
+        :param request_size: number of activities to return, default is all
+        :type request_size: int
         :returns: The full list of activity identifiers (along with their starting timestamps).
         :rtype: tuples of (int, datetime)
         """
         ids = []
         batch_size = 100
+        if request_size < batch_size:
+            batch_size = request_size
         # fetch in batches since the API doesn't allow more than a certain
         # number of activities to be retrieved on every invocation
-        for start_index in range(0, sys.maxsize, batch_size):
+        for start_index in range(0, request_size, batch_size):
             next_batch = self._fetch_activity_ids_and_ts(start_index, batch_size)
             if not next_batch:
                 break

--- a/garminexport/garminclient.py
+++ b/garminexport/garminclient.py
@@ -72,9 +72,9 @@ class GarminClient(object):
 
     Example of use: ::
       with GarminClient("my.sample@sample.com", "secretpassword") as client:
-          ids = client.list_activity_ids()
+          ids = client.list_activities()
           for activity_id in ids:
-               gpx = client.get_activity_gpx(activity_id)
+               gpx = client.get_activity_gpx(activity_id[0])
 
     """
 


### PR DESCRIPTION
Using GarminClient, the normal use case I have is to download the most recent activities - normally a very small number.
When you have a lot of activities it is very slow download the entire list of activities, just to get the most recent one or two.

I propose an update to list_activites() to optionally specify the number of activites to list, adding an int parameter 'request_size'.

Also included in this push is some corrections to the example code given for GarminClient I noticed (and tripped over.) 