### PR TITLE
Add from_date and to_date args to backup downloader

### DIFF
--- a/garminexport/cli/backup.py
+++ b/garminexport/cli/backup.py
@@ -59,6 +59,12 @@ def parse_args() -> argparse.Namespace:
         help=("The maximum number of retries to make on failed attempts to fetch an activity. "
               "Exponential backoff will be used, meaning that the delay between successive attempts "
               "will double with every retry, starting at one second. DEFAULT: {}").format(DEFAULT_MAX_RETRIES))
+    parser.add_argument(
+        "--from-date", metavar="FROM", type=str,
+        help="Lower bound for activity start date. Format yyyymmdd. Comparison in UTC.")
+    parser.add_argument(
+        "--to-date", metavar="TO", type=str,
+        help="Upper bound for activity start date. Format yyyymmdd. Comparison in UTC.")
 
     return parser.parse_args()
 
@@ -73,7 +79,9 @@ def main():
                            backup_dir=args.backup_dir,
                            export_formats=args.format,
                            ignore_errors=args.ignore_errors,
-                           max_retries=args.max_retries)
+                           max_retries=args.max_retries,
+                           from_date=args.from_date,
+                           to_date=args.to_date)
 
     except Exception as e:
         log.error("failed with exception: {}".format(e))

--- a/garminexport/incremental_backup.py
+++ b/garminexport/incremental_backup.py
@@ -2,8 +2,8 @@
 import getpass
 import logging
 import os
-from datetime import timedelta
-from typing import List
+from datetime import timedelta, datetime
+from typing import List, Optional
 
 import garminexport.backup
 from garminexport.backup import supported_export_formats
@@ -13,12 +13,25 @@ from garminexport.retryer import Retryer, ExponentialBackoffDelayStrategy, MaxRe
 log = logging.getLogger(__name__)
 
 
+def _filter_by_date(from_date, to_date, start):
+    if (from_date is None) & (to_date is None):
+        return True
+    elif (from_date is not None) & (to_date is not None):
+        return (start.date() >=  from_date) & (start.date() <= to_date)
+    elif from_date is None:
+        return start.date() <= to_date
+    elif to_date is None:
+        return start.date() >= from_date
+
+
 def incremental_backup(username: str,
                        password: str = None,
                        backup_dir: str = os.path.join(".", "activities"),
                        export_formats: List[str] = None,
                        ignore_errors: bool = False,
-                       max_retries: int = 7):
+                       max_retries: int = 7,
+                       from_date: Optional[str] = None,
+                       to_date: Optional[str] = None):
     """Performs (incremental) backups of activities for a given Garmin Connect account.
 
     :param username: Garmin Connect user name
@@ -30,6 +43,8 @@ def incremental_backup(username: str,
     :param max_retries: The maximum number of retries to make on failed attempts to fetch an activity.
     Exponential backoff will be used, meaning that the delay between successive attempts
     will double with every retry, starting at one second. Default: 7.
+    :param from_date: Optional lower bound for activity start date. Format yyyymmdd. Comparison in UTC.
+    :param to_date: Optional upper bound for activity start date. Format yyyymmdd. Comparison in UTC.
 
     The activities are stored in a local directory on the user's computer.
     The backups are incremental, meaning that only activities that aren't already
@@ -44,6 +59,12 @@ def incremental_backup(username: str,
 
     if not password:
         password = getpass.getpass("Enter password: ")
+
+    if from_date is not None:
+        from_date = datetime.strptime(from_date, "%Y%m%d").date()
+
+    if to_date is not None:
+        to_date = datetime.strptime(to_date, "%Y%m%d").date()
 
     # set up a retryer that will handle retries of failed activity downloads
     retryer = Retryer(
@@ -61,6 +82,14 @@ def incremental_backup(username: str,
         log.info("%s contains %d backed up activities", backup_dir, len(backed_up))
 
         log.info("activities that aren't backed up: %d", len(missing_activities))
+
+        if (from_date is not None) or (to_date is not None):
+            log.info("filter activities by start dates in [%s, %s]", from_date, to_date)
+            missing_activities = list(filter(
+                lambda x: _filter_by_date(from_date, to_date, x[1])
+                , missing_activities
+            ))
+            log.info("after start date filtering %s activities aren't backed up", len(missing_activities))
 
         for index, activity in enumerate(missing_activities):
             id, start = activity


### PR DESCRIPTION
You can now filter backup by providing optional dates. This is solved by adding from_date and to_date args to `incremental_backup` and the cli backup tool. 

The implementation/filtering in `incremental_backup` could have been done simpler. For example by do the filtering inside the download loop. But I figure out that I should follow your example by printing good log messages with count on missings downloads. So then I chose to do the filter outside download loop. 