### PR TITLE
Add a argument("domain") to choose Garmin website.

### DIFF
--- a/garminexport/cli/backup.py
+++ b/garminexport/cli/backup.py
@@ -66,6 +66,10 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--user-agent", type=str, default=DEFAULT_USER_AGENT,
         help="A value to use for the `User-Agent` request header. Use an authentic browser agent string to prevent being blocked by Garmin. A tool such as `user_agent` (`ua`) can be used to generate such values.")
+    parser.add_argument(
+        "--domain", metavar="com", type=str,
+        help="Top level domain of your Garmin Connect website. Default: com.",
+        default="com")
 
     return parser.parse_args()
 
@@ -81,7 +85,8 @@ def main():
                            backup_dir=args.backup_dir,
                            export_formats=args.format,
                            ignore_errors=args.ignore_errors,
-                           max_retries=args.max_retries)
+                           max_retries=args.max_retries,
+                           domain=args.domain)
 
     except Exception as e:
         log.error("failed with exception: {}".format(e))

--- a/garminexport/cli/get_activity.py
+++ b/garminexport/cli/get_activity.py
@@ -43,6 +43,10 @@ def main():
         "--log-level", metavar="LEVEL", type=str,
         help="Desired log output level (DEBUG, INFO, WARNING, ERROR). Default: INFO.",
         default="INFO")
+    parser.add_argument(
+        "--domain", metavar="com", type=str,
+        help="Top level domain of your Garmin Connect website. Default: com.",
+        default="com")
 
     args = parser.parse_args()
 
@@ -63,7 +67,7 @@ def main():
         if not args.password:
             args.password = getpass.getpass("Enter password: ")
 
-        with GarminClient(args.username, args.password) as client:
+        with GarminClient(args.username, args.password, domain=args.domain) as client:
             log.info("fetching activity %s ...", args.activity)
             summary = client.get_activity_summary(args.activity)
             # set up a retryer that will handle retries of failed activity downloads

--- a/garminexport/cli/upload_activity.py
+++ b/garminexport/cli/upload_activity.py
@@ -2,6 +2,7 @@
 """A program that uploads an activity file to a Garmin Connect account.
 """
 import argparse
+from garminexport import cli
 import getpass
 import logging
 
@@ -38,6 +39,10 @@ def main():
         "--log-level", metavar="LEVEL", type=str,
         help="Desired log output level (DEBUG, INFO, WARNING, ERROR). Default: INFO.",
         default="INFO")
+    parser.add_argument(
+        "--domain", metavar="com", type=str,
+        help="Top level domain of your Garmin Connect website. Default: com.",
+        default="com")
 
     args = parser.parse_args()
 
@@ -53,7 +58,7 @@ def main():
         if not args.password:
             args.password = getpass.getpass("Enter password: ")
 
-        with GarminClient(args.username, args.password) as client:
+        with GarminClient(args.username, args.password, domain=args.domain) as client:
             for activity in args.activity:
                 log.info("uploading activity file %s ...", activity.name)
                 try:
@@ -62,7 +67,7 @@ def main():
                 except Exception as e:
                     log.error("upload failed: {!r}".format(e))
                 else:
-                    log.info("upload successful: https://connect.garmin.com/modern/activity/%s", id)
+                    log.info("upload successful: %s/modern/activity/%s", client.connect_host, id)
 
     except Exception as e:
         log.error("failed with exception: %s", e)

--- a/garminexport/cli/upload_activity.py
+++ b/garminexport/cli/upload_activity.py
@@ -2,7 +2,6 @@
 """A program that uploads an activity file to a Garmin Connect account.
 """
 import argparse
-from garminexport import cli
 import getpass
 import logging
 

--- a/garminexport/garminclient.py
+++ b/garminexport/garminclient.py
@@ -145,8 +145,7 @@ class GarminClient(object):
 
         auth_response = self.session.post(
             self.SSO_SIGNIN_URL, headers=headers, params=self._auth_params(), data=form_data)
-        log.debug(self.SSO_SIGNIN_URL, self._auth_params())
-        # log.debug("got auth response: %s", auth_response.text)
+        log.debug("got auth response: %s", auth_response.text)
         if auth_response.status_code != 200:
             raise ValueError("authentication failure: did you enter valid credentials?")
         auth_ticket_url = self._extract_auth_ticket_url(auth_response.text)

--- a/garminexport/garminclient.py
+++ b/garminexport/garminclient.py
@@ -96,7 +96,6 @@ class GarminClient(object):
         self._user_agent_fn = user_agent_fn
 
         domain = domain if domain is not None else "com"
-        print(domain)
         self.sso_host = "https://sso.garmin.{}".format(domain)
         self.connect_host = "https://connect.garmin.{}".format(domain)
 

--- a/garminexport/incremental_backup.py
+++ b/garminexport/incremental_backup.py
@@ -19,7 +19,8 @@ def incremental_backup(username: str,
                        backup_dir: str = os.path.join(".", "activities"),
                        export_formats: List[str] = None,
                        ignore_errors: bool = False,
-                       max_retries: int = 7):
+                       max_retries: int = 7,
+                       domain: str = "com"):
     """Performs (incremental) backups of activities for a given Garmin Connect account.
 
     :param username: Garmin Connect user name
@@ -36,6 +37,8 @@ def incremental_backup(username: str,
     :param max_retries: The maximum number of retries to make on failed attempts to fetch an activity.
     Exponential backoff will be used, meaning that the delay between successive attempts
     will double with every retry, starting at one second. Default: 7.
+    :keyword domain: Top level domain of your Garmin Connect website. Default: com.
+    :type domain: str
 
     The activities are stored in a local directory on the user's computer.
     The backups are incremental, meaning that only activities that aren't already
@@ -57,7 +60,7 @@ def incremental_backup(username: str,
         delay_strategy=ExponentialBackoffDelayStrategy(initial_delay=timedelta(seconds=1)),
         stop_strategy=MaxRetriesStopStrategy(max_retries))
 
-    with GarminClient(username, password, user_agent_fn) as client:
+    with GarminClient(username, password, user_agent_fn, domain=domain) as client:
         # get all activity ids and timestamps from Garmin account
         log.info("scanning activities for %s ...", username)
         activities = set(retryer.call(client.list_activities))

--- a/samples/lab.py
+++ b/samples/lab.py
@@ -25,6 +25,10 @@ if __name__ == "__main__":
     # optional args
     parser.add_argument(
         "--password", type=str, help="Account password.")
+    parser.add_argument(
+        "--domain", metavar="com", type=str,
+        help="Top level domain of your Garmin Connect website. Default: com.",
+        default="com")
 
     args = parser.parse_args()
     print(args)
@@ -32,7 +36,7 @@ if __name__ == "__main__":
     if not args.password:
         args.password = getpass.getpass("Enter password: ")
         
-    client = GarminClient(args.username, args.password)
+    client = GarminClient(args.username, args.password, domain=args.domain)
     client.connect()
 
     print("client object ready for use.")

--- a/samples/sample.py
+++ b/samples/sample.py
@@ -24,10 +24,6 @@ if __name__ == "__main__":
         "--domain", metavar="com", type=str,
         help="Top level domain of your Garmin Connect website. Default: com.",
         default="INFO")
-    parser.add_argument(
-        "--domain", metavar="com", type=str,
-        help="Top level domain of your Garmin Connect website. Default: com.",
-        default="com")
 
     args = parser.parse_args()
     print(args)

--- a/samples/sample.py
+++ b/samples/sample.py
@@ -20,6 +20,14 @@ if __name__ == "__main__":
     # optional args
     parser.add_argument(
         "--password", type=str, help="Account password.")
+    parser.add_argument(
+        "--domain", metavar="com", type=str,
+        help="Top level domain of your Garmin Connect website. Default: com.",
+        default="INFO")
+    parser.add_argument(
+        "--domain", metavar="com", type=str,
+        help="Top level domain of your Garmin Connect website. Default: com.",
+        default="com")
 
     args = parser.parse_args()
     print(args)
@@ -28,7 +36,7 @@ if __name__ == "__main__":
         args.password = getpass.getpass("Enter password: ")
 
     try:
-        with GarminClient(args.username, args.password) as client:
+        with GarminClient(args.username, args.password, domain=args.domain) as client:
             log.info("activities:")
             activity_ids = client.list_activities()
             log.info("num ids: %d", len(activity_ids))

--- a/samples/sample.py
+++ b/samples/sample.py
@@ -23,7 +23,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--domain", metavar="com", type=str,
         help="Top level domain of your Garmin Connect website. Default: com.",
-        default="INFO")
+        default="com")
 
     args = parser.parse_args()
     print(args)


### PR DESCRIPTION
Add a argument("domain") to choose Garmin website. The value is the top level domain of your Garmin Connect website.
This is mainly for mainland China users, because their Internet is different from the rest of the world. They use a ".cn" website.
So pass the argument as "--domain=cn" will work. The default value is com, so others don't need to change.