### PR TITLE
Bypass cloud flare hurdle, add login retry, add access method

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,5 +15,8 @@ wheel:
 	@echo "wheel found at:"
 	find . -type f -name \*.whl
 
-reinstall:	wheel
+reinstall:	clean wheel
 	pip install `find . -type f -name \*.whl` --force-reinstall
+
+uninstall:
+	pip uninstall -y garminexport

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,15 @@ venv:
 clean:
 	find -name '*~' -exec rm {} \;
 	find -name '*pyc' -exec rm {} \;
+	rm -rf build dist garminexport.egg-info
 
 test:
 	nosetests --verbose --with-coverage --cover-package=garminexport --cover-branches
+
+wheel:
+	python setup.py bdist_wheel
+	@echo "wheel found at:"
+	find . -type f -name \*.whl
+
+reinstall:	wheel
+	pip install `find . -type f -name \*.whl` --force-reinstall

--- a/garminexport/garminclient.py
+++ b/garminexport/garminclient.py
@@ -18,6 +18,7 @@ from io import BytesIO
 import dateutil
 import dateutil.parser
 import requests
+import cloudscraper
 
 from garminexport.retryer import Retryer, ExponentialBackoffDelayStrategy, MaxRetriesStopStrategy
 
@@ -110,7 +111,7 @@ class GarminClient(object):
         self.disconnect()
 
     def connect(self):
-        self.session = requests.Session()
+        self.session = cloudscraper.create_scraper()
         self._authenticate()
 
     def disconnect(self):
@@ -128,6 +129,7 @@ class GarminClient(object):
             "_csrf": self._get_csrf_token(),
         }
         headers = {
+            'Content-Encoding': 'deflate, gzip',
             'origin': 'https://sso.garmin.com',
         }
         if self._user_agent_fn:

--- a/garminexport/garminclient.py
+++ b/garminexport/garminclient.py
@@ -179,7 +179,6 @@ class GarminClient(object):
         )
         resp: Response = retryer.call(
             self.session.get, SSO_LOGIN_URL, params=self._auth_params())
-        # resp = self.session.get(SSO_LOGIN_URL, params=self._auth_params())
         if resp.status_code != 200:
             raise ValueError("auth failure: could not load {}".format(SSO_LOGIN_URL))
 

--- a/garminexport/retryer.py
+++ b/garminexport/retryer.py
@@ -204,6 +204,7 @@ class Retryer(object):
                 log.debug('{%s}: failed: return value: %s', name, returnval)
             except Exception as e:
                 if self.error_strategy is None or not self.error_strategy.should_suppress(e):
+                    log.debug(f'not suppressing: {e} ({type(e)})')
                     raise e
                 log.debug('{%s}: failed: error: %s', name, e)
             elapsed_time = datetime.now() - start

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 requires = [
     'requests>=2.0,<3',
     'python-dateutil~=2.4',
+    'cloudscraper~=1.2.0',
 ]
 
 test_requires = [


### PR DESCRIPTION
This pull request: 

* Adds the [cloudflare](https://github.com/petergardfjall/garminexport/pull/80) update to enable logins,
* Updates the URL touched per *ceremoniously* login (necessary in my case),
* Adds a login retry (necessary in my case).
* Add a public accessor to fetch activities.