### PR TITLE
Include session header {'NK': 'NT'} to avoid 402 responses.

### DIFF
--- a/garminexport/garminclient.py
+++ b/garminexport/garminclient.py
@@ -167,7 +167,9 @@ class GarminClient(object):
         # appears like we need to touch base with the main page to complete the
         # login ceremony.
         self.session.get('https://connect.garmin.com/modern')
-
+        # This header appears to be needed on subsequent session requests or we
+        # end up with a 402 response from Garmin.
+        self.session.headers.update({'NK': 'NT'})
 
     def _get_csrf_token(self):
         """Retrieves a Cross-Site Request Forgery (CSRF) token from Garmin's login


### PR DESCRIPTION
This is a more condensed version of https://github.com/petergardfjall/garminexport/pull/92

Credit to @nowster in the commit.