### PR TITLE
README: pip command that works with zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ you should install the module with the `impersonate_browser`
 like so:
 
 ```bash
-pip install garminexport[impersonate_browser]
+pip install 'garminexport[impersonate_browser]'
 ```
 
 This replaces the default [requests](https://github.com/psf/requests) library


### PR DESCRIPTION
As highlighted [here](https://stackoverflow.com/questions/30539798/zsh-no-matches-found-requestssecurity), zsh use square brackets for pattern matching. This change should be compatible with other shells, too. 