### PR TITLE
rely on tokens from manual user login

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ venv: $(VENV_DIR)
 
 # install pinned dependencies and package itself in editable mode
 dep-sync: $(VENV_DIR)
-	(source $(VENV_ACTIVATE); pip install -r requirements-dev.txt ; pip install -e .[impersonate_browser])
+	(source $(VENV_ACTIVATE); pip install -r requirements-dev.txt ; pip install -e .)
 
 # creates a virtualenv with development dependencies installed
 dev-init: dep-sync

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 # About
 
 `garminexport` is both a library and a tool for downloading/backing up
-[Garmin Connect](http://connect.garmin.com/) activities to a local disk.
+[Garmin Connect](http://connect.garmin.com/) activities to local disk.
 
 The main utility script is called `garmin-backup` and performs incremental
 backups of your Garmin account to a local directory. The first time
@@ -17,43 +17,11 @@ activities that haven't already been downloaded to the backup directory.
 # Installation
 
 `garminexport` is available on [PyPi](https://pypi.org/) and can be installed
-with [pip](http://pip.readthedocs.org).
-
-## Vanilla installation
-
-> **WARNING**
->
-> GarminConnect employs Cloudflare's bot protection to prevent scripted access
-> to their services. Therefore a vanilla installation is no longer likely to
-> work. Instead, try the
-> [Browser-impersonating installation](#browser-impersonating-installation)
-> below.
-
-To only install `garminexport` and required dependencies run:
+with [pip](http://pip.readthedocs.org):
 
 ```bash
 pip install garminexport
 ```
-
-## Browser-impersonating installation
-
-To install `garminexport` with support to circumvent Cloudflare's bot protection
-you should install the module with the `impersonate_browser`
-[extra](https://setuptools.pypa.io/en/latest/userguide/dependency_management.html#optional-dependencies)
-like so:
-
-```bash
-pip install 'garminexport[impersonate_browser]'
-```
-
-This replaces the default [requests](https://github.com/psf/requests) library
-with [curl_cffi](https://github.com/yifeikong/curl_cffi) for HTTP session
-handling.
-
-When `curl_cffi` is used, the `GARMINEXPORT_IMPERSONATE_BROWSER` environment
-variable can be used to control which browser is impersonated (default is
-`chrome110`, see
-[full list](https://github.com/lwthiker/curl-impersonate#supported-browsers)).
 
 # Usage
 
@@ -63,13 +31,56 @@ To be of any use you need to register an account at
 [Garmin Connect](http://connect.garmin.com/) and populate it with some
 activities.
 
+## Authentication
+
+> [!NOTE]  
+> <sub>It has been proposed (e.g. in
+> [#102](https://github.com/petergardfjall/garminexport/issues/102)) that
+> `garminexport` be migrated to use [garth](https://github.com/matin/garth), a
+> library that uses API secrets from the Garmin Connect Android app. Although
+> admittedly an approach more suitable for automation, the legal implications of
+> using such API secrets without
+> [proper permit](https://www.garmin.com/en-US/forms/GarminConnectDeveloperAccess/)
+> are unclear.</sub>
+>
+> <sub>Instead `garminexport` sticks to its original spirit of only doing what a
+> human user would rightfully be able to do through the web browser. This does
+> come at the price of requiring some manual work.</sub>
+
+Over the years Garmin has made it increasingly difficult to programatically
+access their site (without a
+[proper permit](https://www.garmin.com/en-US/forms/GarminConnectDeveloperAccess/)
+and API keys, which are only handed out to businesses). They have systematically
+added bot protection (such as browser detection and CAPTCHAs) to their
+authentication flow to prevent scripted access. Trying to keep up with this over
+time became unsustainable.
+
+As of version `0.6.0` of `garminexport`, the authentication flow was reworked to
+rely on the human user to perform the actual login _through a web-browser_ and
+then, via web browser developer tools, extract the tokens needed to authenticate
+further client interactions (proposed by @ryeguard in
+https://github.com/petergardfjall/garminexport/pull/115).
+
+After logging in at https://connect.garmin.com (using your web browser of
+choice) there are two tokens that need to be supplied to `garminexport` for it
+to authenticate its client requests:
+
+- A `JWT_FGP` cookie: extract its value through web browser developer tools by
+  looking at cookies stored for https://connect.garmin.com.
+- An OAuth bearer token: extract its value through web browser developer tools
+  by looking at the request (not response) `Headers` of a network request. The
+  header to look for is `Authorization` and the the token value is everything
+  following the leading `Bearer` string.
+
 ## As a command-line tool (garmin-backup)
 
-The backup program is run as follows (use the `--help` flag for a full list of
-available options):
+The backup program is run as follows, with `--bearer-token` and
+`--jwt-fgp-cookie` extracted as explained in the section on
+[Authentication](#authentication). Use the `--help` flag for a full list of
+available options:
 
 ```bash
-garmin-backup --backup-dir=activities <username or email>
+garmin-backup --backup-dir=activities --bearer-token="eyJ[..]Q4g" --jwt-fgp-cookie=5768b018-dda6-4e51-add9-f4b8eb5c1758
 ```
 
 Once started, the program will prompt you for your account password and then log
@@ -145,15 +156,9 @@ For example, in your `setup.py`, `setup.cfg`, `pyproject.toml`
 ```python
 install_requires=[
     'garminexport',
-    # also installs 'impersonate_browser as a dependency
-    # 'garminexport[impersonate_browser]',
     ...
 ]
 ```
-
-Note: if you happen to have
-[cloudscraper](https://github.com/VeNoMouS/cloudscraper) on your `PACKAGEPATH`
-`GarminClient` will make use of it whenever it needs to make an HTTP request.
 
 # Contribute
 

--- a/garminexport/cli/backup.py
+++ b/garminexport/cli/backup.py
@@ -31,12 +31,18 @@ def parse_args() -> argparse.Namespace:
             "given Garmin Connect account. Only activities that "
             "aren't already stored in the backup directory will "
             "be downloaded."))
-    # positional args
+
     parser.add_argument(
-        "username", metavar="<username>", type=str, help="Account user name.")
-    # optional args
+        "--bearer-token", default=None, type=str,
+        help=("""Bearer authentication token to use as Authorization request header.
+        Extract through developer tools from an active web browser session.
+        Must be used together with --jwt-fgp-cookie."""))
     parser.add_argument(
-        "--password", type=str, help="Account password.")
+        "--jwt-fgp-cookie", default=None, type=str,
+        help=("""Authentication JWT_FGP cookie.
+        Extract through developer tools from an active web browser session.
+        Must be used together with --bearer-token."""))
+
     parser.add_argument(
         "--backup-dir", metavar="DIR", type=str,
         help="Destination directory for downloaded activities. Default: ./activities/",
@@ -67,8 +73,9 @@ def main():
     logging.root.setLevel(LOG_LEVELS[args.log_level])
 
     try:
-        incremental_backup(username=args.username,
-                           password=args.password,
+        incremental_backup(bearer_token=args.bearer_token,
+                           jwt_fgp_cookie=args.jwt_fgp_cookie,
+
                            backup_dir=args.backup_dir,
                            export_formats=args.format,
                            ignore_errors=args.ignore_errors,

--- a/garminexport/garminclient.py
+++ b/garminexport/garminclient.py
@@ -24,15 +24,6 @@ log = logging.getLogger(__name__)
 logging.getLogger("requests").setLevel(logging.ERROR)
 
 
-PORTAL_LOGIN_URL = "https://sso.garmin.com/portal/api/login"
-"""Garmin Connect's Single-Sign On login URL."""
-SSO_LOGIN_URL = "https://sso.garmin.com/sso/login"
-"""Garmin Connect's Single-Sign On login URL."""
-SSO_SIGNIN_URL = "https://sso.garmin.com/sso/signin"
-"""The Garmin Connect Single-Sign On sign-in URL. This is where the login form
-gets POSTed."""
-
-
 def require_session(client_function):
     """Decorator that is used to annotate :class:`GarminClient`
     methods that need an authenticated session before being called.
@@ -59,26 +50,33 @@ class GarminClient(object):
     a failure occurs.
 
     Example of use: ::
-      with GarminClient("my.sample@sample.com", "secretpassword") as client:
+      with GarminClient(bearer_token="..", jwt_fgp_cookie="..") as client:
           ids = client.list_activity_ids()
           for activity_id in ids:
                gpx = client.get_activity_gpx(activity_id)
 
     """
 
-    def __init__(self, username, password):
+    def __init__(self, bearer_token, jwt_fgp_cookie):
         """Initialize a :class:`GarminClient` instance.
 
-        :param username: Garmin Connect user name or email address.
-        :type username: str
-        :param password: Garmin Connect account password.
-        :type password: str
+
+        :param bearer_token: This is the OAuth bearer token to use for the
+        Authorization header in client requests. It needs to be extracted using
+        web browser developer tools from an active Garmin Connect session (with
+        a successful login).
+        :type bearer_token: str
+
+        :param jwt_fgp_cookie: This is the JWT_FGP cookie to use in client
+        requests. It needs to be extracted using web browser developer tools
+        from an active Garmin Connect session (with a successful login).
+        :type jwt_fgp_cookie: str
+
         """
-        self.username = username
-        self.password = password
+        self.bearer_token = bearer_token
+        self.jwt_fgp_cookie = jwt_fgp_cookie
 
         self.session = None
-
 
     def __enter__(self):
         self.connect()
@@ -88,149 +86,36 @@ class GarminClient(object):
         self.disconnect()
 
     def connect(self):
-        self.session = new_http_session()
-        self._authenticate()
+        self.session = requests.session()
+
+        if not (self.bearer_token and self.jwt_fgp_cookie):
+            raise ValueError("both bearer_token and jwt_fgp_cookie are required for authentication")
+        self._authenticate_with_token()
 
     def disconnect(self):
         if self.session:
             self.session.close()
             self.session = None
 
-    def _authenticate(self):
-        """
-        Authenticates using a Garmin Connect username and password.
-
-        The procedure has changed over the years. A good approach for figuring
-        it out is to use the browser development tools to trace all requests
-        following a sign-in.
-        """
-        log.info("authenticating user ...")
-
-        auth_ticket_url = self._login(self.username, self.password)
-        log.debug("auth ticket url: '%s'", auth_ticket_url)
-
-        self._claim_auth_ticket(auth_ticket_url)
-
-        # we need to touch base with the main page to complete the login ceremony.
-        self.session.get('https://connect.garmin.com/modern')
-        # This header appears to be needed on subsequent session requests or we
-        # end up with a 402 response from Garmin.
-        self.session.headers.update({'NK': 'NT'})
-
-        # We need to pass an Authorization oauth token with subsequent requests.
-        auth_token = self._get_oauth_token()
-        token_type = auth_token['token_type']
-        access_token = auth_token['access_token']
+    def _authenticate_with_token(self):
+        """Authenticates using a OAuth bearer token and JWT_FGP cookie token
+        extracted from an existing web browser login."""
+        log.info("authenticating user with OAuth Bearer token and JWT_FGP cooke token ...")
         self.session.headers.update(
             {
-                'Authorization': f'{token_type} {access_token}',
-                'Di-Backend': 'connectapi.garmin.com',
-            })
+                "Authorization": f"Bearer {self.bearer_token}",
+                "Di-Backend": "connectapi.garmin.com",
+                "NK": "NT",
+            }
+        )
+        self.session.cookies.update({"JWT_FGP": self.jwt_fgp_cookie})
 
-
-    def _get_oauth_token(self):
-        """Retrieve an OAuth token to use for the session.
-
-        Typically looks something like the following. The 'access_token'
-        needs to be passed in the 'Authorization' header for remaining session
-        requests.
-
-          {
-            "scope": "...",
-            "jti": "...",
-            "access_token": "...",
-            "token_type": "Bearer",
-            "refresh_token": "...",
-            "expires_in": 3599,
-            "refresh_token_expires_in": 7199
-          }
-        """
-        log.info("getting oauth token ...")
-        headers = {
-            'authority': 'connect.garmin.com',
-            'origin': 'https://connect.garmin.com',
-            'referer': 'https://connect.garmin.com/modern/',
-        }
-        resp = self.session.post('https://connect.garmin.com/modern/di-oauth/exchange',
-                                 headers=headers)
-        if resp.status_code != 200:
-            raise ValueError(f'get oauth token failed with {resp.status_code}: {resp.text}')
-        return resp.json()
-
-
-    def _login(self, username, password):
-        """Logs in with the supplied account credentials.
-        The return value is a URL where the created authentication ticket can be claimed.
-        For example, "https://connect.garmin.com/modern?ticket=ST-2550833-30KdiEJ3jqvFzLNGi2C7-sso"
-
-        The response message looks typically something like this:
-          {
-             "serviceURL":"https://connect.garmin.com/modern/",
-             "serviceTicketId":"ST-2550833-30KdiEJ3jqvFzLNGi2C7-sso",
-             "responseStatus":{"type":"SUCCESSFUL","message":"","httpStatus":"OK"},
-             "customerMfaInfo":null,
-             "consentTypeList":null
-          }
-        """
-        headers = {
-            'authority': 'sso.garmin.com',
-            'origin': 'https://sso.garmin.com',
-            'referer': 'https://sso.garmin.com/portal/sso/en-US/sign-in?clientId=GarminConnect&service=https%3A%2F%2Fconnect.garmin.com%2Fmodern',
-        }
-        params = {
-            "clientId": "GarminConnect",
-            "service": "https://connect.garmin.com/modern/",
-            "gauthHost": "https://sso.garmin.com/sso",
-        }
-        form_data = {'username': username, 'password': password}
-
-        log.info("passing login credentials ...")
-        resp = self.session.post(PORTAL_LOGIN_URL, headers=headers, params=params, json=form_data)
-        log.debug("got auth response %d: %s", resp.status_code, resp.text)
-        if resp.status_code != 200:
-            raise ValueError(f'authentication attempt failed with {resp.status_code}: {resp.text}')
-        return self._extract_auth_ticket_url(resp.json())
-
-    def _claim_auth_ticket(self, auth_ticket_url):
-        # Note: first we bump the login URL.
-        p = {
-            'clientId': 'GarminConnect',
-            'service': 'https://connect.garmin.com/modern/',
-            'webhost': 'https://connect.garmin.com',
-            'gateway': 'true',
-            'generateExtraServiceTicket': 'true',
-            'generateTwoExtraServiceTickets': 'true',
-        }
-        self.session.get(SSO_LOGIN_URL, headers={}, params=p)
-
-        log.info("claiming auth ticket %s ...", auth_ticket_url)
-        response = self.session.get(auth_ticket_url)
+        # Make a probe request as a validation of proper auth credentials.
+        response = self.session.get(
+            "https://connect.garmin.com/userprofile-service/userprofile/user-settings")
         if response.status_code != 200:
-            raise RuntimeError(
-                "auth failure: failed to claim auth ticket: {}: {}\n{}".format(
-                    auth_ticket_url, response.status_code, response.text))
-
-
-    @staticmethod
-    def _extract_auth_ticket_url(auth_response):
-        """Extracts an authentication ticket URL from the response of an
-        authentication form submission. The auth ticket URL is typically
-        of form:
-
-          https://connect.garmin.com/modern?ticket=ST-0123456-aBCDefgh1iJkLmN5opQ9R-cas
-
-        :param auth_response: JSON response from a login form submission.
-        """
-        if auth_response['responseStatus']['type'] == 'INVALID_USERNAME_PASSWORD':
-            RuntimeError("authentication failure: did you provide a correct username/password?")
-        service_url = auth_response.get('serviceURL')
-        auth_ticket = auth_response.get('serviceTicketId')
-        if not service_url:
-            raise RuntimeError("auth failure: unable to extract serviceURL")
-        if not auth_ticket:
-            raise RuntimeError("auth failure: unable to extract serviceTicketId")
-        auth_ticket_url = service_url.rstrip('/') + '?ticket=' + auth_ticket
-        return auth_ticket_url
+            raise Exception('Probe request failed. Did you supply proper credentials?')
+        log.debug("probe response: %s", response.json())
 
     @require_session
     def list_activities(self):
@@ -555,24 +440,3 @@ class GarminClient(object):
                     activity_id, response.status_code, response.text))
 
         return activity_id
-
-
-def new_http_session():
-    """Returns a requests-compatible HTTP Session.
-    See https://requests.readthedocs.io/en/latest/user/advanced/#session-objects.
-
-    By default it uses the requests library to create http sessions. If built with
-    the 'impersonate-browser' extra, it will use curl_cffi and a patched libcurl to
-    produce identical TLS fingerprints as a real web browsers to circumvent
-    Cloudflare's bot protection.
-    """
-    session_factory_func = requests.session
-    try:
-        import curl_cffi.requests
-        # For supported browsers: see https://github.com/lwthiker/curl-impersonate#supported-browsers
-        browser = os.getenv("GARMINEXPORT_IMPERSONATE_BROWSER", "chrome110")
-        log.info("using 'curl_cffi' to create HTTP sessions that impersonate web browser '%s' ...", browser)
-        session_factory_func = partial(curl_cffi.requests.Session, impersonate=browser)
-    except (ImportError):
-        pass
-    return session_factory_func()

--- a/garminexport/incremental_backup.py
+++ b/garminexport/incremental_backup.py
@@ -1,5 +1,4 @@
 #! /usr/bin/env python
-import getpass
 import logging
 import os
 from datetime import timedelta
@@ -13,26 +12,40 @@ from garminexport.retryer import Retryer, ExponentialBackoffDelayStrategy, MaxRe
 log = logging.getLogger(__name__)
 
 
-def incremental_backup(username: str,
-                       password: str = None,
+def incremental_backup(bearer_token: str = None,
+                       jwt_fgp_cookie: str = None,
+
                        backup_dir: str = os.path.join(".", "activities"),
                        export_formats: List[str] = None,
                        ignore_errors: bool = False,
                        max_retries: int = 7):
     """Performs (incremental) backups of activities for a given Garmin Connect account.
 
-    :param username: Garmin Connect user name
-    :param password: Garmin Connect user password. Default: None. If not provided, would be asked interactively.
-    :param backup_dir: Destination directory for downloaded activities. Default: ./activities/".
-    :param export_formats: List of desired output formats (json_summary, json_details, gpx, tcx, fit).
-    Default: `None` which means all supported formats will be backed up.
-    :param ignore_errors: Ignore errors and keep going. Default: False.
-    :param max_retries: The maximum number of retries to make on failed attempts to fetch an activity.
-    Exponential backoff will be used, meaning that the delay between successive attempts
-    will double with every retry, starting at one second. Default: 7.
+    :param bearer_token: This is the OAuth bearer token to use for the
+    Authorization header in client requests. It needs to be extracted using web
+    browser developer tools from an active Garmin Connect session (with a
+    successful login).
 
-    The activities are stored in a local directory on the user's computer.
-    The backups are incremental, meaning that only activities that aren't already
+    :param jwt_fgp_cookie: This is the JWT_FGP cookie to use in client
+    requests. It needs to be extracted using web browser developer tools from
+    an active Garmin Connect session (with a successful login).
+
+    :param backup_dir: Destination directory for downloaded
+    activities. Default: ./activities/".
+
+    :param export_formats: List of desired output formats (json_summary,
+    json_details, gpx, tcx, fit).  Default: `None` which means all supported
+    formats will be backed up.
+
+    :param ignore_errors: Ignore errors and keep going. Default: False.
+
+    :param max_retries: The maximum number of retries to make on failed
+    attempts to fetch an activity. Exponential backoff will be used, meaning
+    that the delay between successive attempts will double with every retry,
+    starting at one second. Default: 7.
+
+    The activities are stored in a local directory on the user's computer.  The
+    backups are incremental, meaning that only activities that aren't already
     stored in the backup directory will be downloaded.
 
     """
@@ -43,17 +56,19 @@ def incremental_backup(username: str,
     if not os.path.isdir(backup_dir):
         os.makedirs(backup_dir)
 
-    if not password:
-        password = getpass.getpass("Enter password: ")
+    if not bearer_token:
+        bearer_token = input("Enter Authorization header bearer token (extract with web browser developer tools): ")
+    if not jwt_fgp_cookie:
+        jwt_fgp_cookie = input("Enter JWT_FGP cookie value (extract with web browser developer tools): ")
 
     # set up a retryer that will handle retries of failed activity downloads
     retryer = Retryer(
         delay_strategy=ExponentialBackoffDelayStrategy(initial_delay=timedelta(seconds=1)),
         stop_strategy=MaxRetriesStopStrategy(max_retries))
 
-    with GarminClient(username, password) as client:
+    with GarminClient(bearer_token, jwt_fgp_cookie) as client:
         # get all activity ids and timestamps from Garmin account
-        log.info("scanning activities for %s ...", username)
+        log.info("scanning activities ...")
         activities = set(retryer.call(client.list_activities))
         log.info("account has a total of %d activities", len(activities))
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,11 +42,6 @@ install_requires =
     python-dateutil~=2.4
 
 [options.extras_require]
-# Note: needed to impersonate web browsers. Garmin Connect uses Cloudflare's bot
-# protection which looks at TLS fingerprints to determine if the caller is a
-# script (like curl) or a web browser. curl_cffi uses a patched libcurl to
-# produce identical TLS fingerprints as real web browsers.
-impersonate_browser = curl_cffi==0.5.9
 test = pytest~=7.3; pytest-cov~=4.0
 
 [options.entry_points]


### PR DESCRIPTION
A complete overhaul of the authentication.
With this `garminexport` relies _entirely_ on tokens from a _manual_ user login (performed through the web browser).

Given how Garmin makes it increasingly difficult to access their site programatically (a CAPTCHA prevents the latest approach), this seems to be the best we can do at the moment without resorting to using "stolen" API/app credentials like [garth](https://github.com/matin/garth).

Based on the proposal of @ryeguard in https://github.com/petergardfjall/garminexport/pull/115.

The new authentication approach is outlined in https://github.com/petergardfjall/garminexport/blob/auth-overhaul/README.md#authentication