### PR TITLE
change authentication flow to avoid bot protection 

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v3

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ venv: $(VENV_DIR)
 
 # install pinned dependencies and package itself in editable mode
 dep-sync: $(VENV_DIR)
-	(source $(VENV_ACTIVATE); pip install -r requirements-dev.txt ; pip install -e .[impersonate_browser])
+	(source $(VENV_ACTIVATE); pip install -r requirements-dev.txt ; pip install -e .)
 
 # creates a virtualenv with development dependencies installed
 dev-init: dep-sync

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 # About
 
 `garminexport` is both a library and a tool for downloading/backing up
-[Garmin Connect](http://connect.garmin.com/) activities to a local disk.
+[Garmin Connect](http://connect.garmin.com/) activities to local disk.
 
 The main utility script is called `garmin-backup` and performs incremental
 backups of your Garmin account to a local directory. The first time
@@ -19,41 +19,9 @@ activities that haven't already been downloaded to the backup directory.
 `garminexport` is available on [PyPi](https://pypi.org/) and can be installed
 with [pip](http://pip.readthedocs.org).
 
-## Vanilla installation
-
-> **WARNING**
->
-> GarminConnect employs Cloudflare's bot protection to prevent scripted access
-> to their services. Therefore a vanilla installation is no longer likely to
-> work. Instead, try the
-> [Browser-impersonating installation](#browser-impersonating-installation)
-> below.
-
-To only install `garminexport` and required dependencies run:
-
 ```bash
 pip install garminexport
 ```
-
-## Browser-impersonating installation
-
-To install `garminexport` with support to circumvent Cloudflare's bot protection
-you should install the module with the `impersonate_browser`
-[extra](https://setuptools.pypa.io/en/latest/userguide/dependency_management.html#optional-dependencies)
-like so:
-
-```bash
-pip install 'garminexport[impersonate_browser]'
-```
-
-This replaces the default [requests](https://github.com/psf/requests) library
-with [curl_cffi](https://github.com/yifeikong/curl_cffi) for HTTP session
-handling.
-
-When `curl_cffi` is used, the `GARMINEXPORT_IMPERSONATE_BROWSER` environment
-variable can be used to control which browser is impersonated (default is
-`chrome110`, see
-[full list](https://github.com/lwthiker/curl-impersonate#supported-browsers)).
 
 # Usage
 
@@ -62,6 +30,22 @@ variable can be used to control which browser is impersonated (default is
 To be of any use you need to register an account at
 [Garmin Connect](http://connect.garmin.com/) and populate it with some
 activities.
+
+## Authentication
+
+Logging in with the user-supplied username and password gives `garminexport` two
+important pieces of data needed to authenticate further client requests:
+
+- An OAuth bearer token.
+- A `JWT_FGP` cookie.
+
+These are both stored under `~/.garmexport` (or the folder given by
+`--auth-token-dir`) and will be reused as long as the OAuth token has not
+expired. Only if the OAuth token has expired (normally after two hours) will a
+new login be initiated. Doing too many logins in a short period of time risks
+seeing your IP address being temporarily blocked by CloudFlare (normally
+indicated by a `429 (Too Many Requests)` response). The reuse of authentication
+tokens should make this a non-issue though.
 
 ## As a command-line tool (garmin-backup)
 
@@ -145,15 +129,9 @@ For example, in your `setup.py`, `setup.cfg`, `pyproject.toml`
 ```python
 install_requires=[
     'garminexport',
-    # also installs 'impersonate_browser as a dependency
-    # 'garminexport[impersonate_browser]',
     ...
 ]
 ```
-
-Note: if you happen to have
-[cloudscraper](https://github.com/VeNoMouS/cloudscraper) on your `PACKAGEPATH`
-`GarminClient` will make use of it whenever it needs to make an HTTP request.
 
 # Contribute
 

--- a/garminexport/authenticator.py
+++ b/garminexport/authenticator.py
@@ -1,0 +1,291 @@
+from collections.abc import Callable
+import logging
+from functools import wraps
+import re
+import requests
+import requests.sessions
+from requests.sessions import Session
+from typing import TypeAlias
+
+from garminexport.token_store import JwtFgpCookie
+from garminexport.token_store import OAuthToken
+from garminexport.token_store import TokenStore
+
+log = logging.getLogger(__name__)
+
+CASTicket: TypeAlias = str
+"""A CAS service ticket like "ST-01055566-3753GCopsoOm6yWrrXro-cas"."""
+
+SSO_EMBED_URL = "https://sso.garmin.com/sso/embed"
+"""Garmin Connect's single-signon embed URL."""
+SSO_SIGNIN_URL = "https://sso.garmin.com/sso/signin"
+"""The Garmin Connect single-signon signin URL. This is where the login form
+gets POSTed to get a CASTicket."""
+OAUTH_EXCHANGE_URL = 'https://connect.garmin.com/modern/di-oauth/exchange'
+"""URL to be called once a CAS ticket has been validated to exchange it for an
+OAuth token."""
+
+AUTH_TOKEN_REFRESH_URL = \
+    "https://connect.garmin.com/services/auth/token/refresh"
+"""Expects a POST with input JSON body like {"refresh_token": "eyJyZ..Q=="}.
+On success it returns 201 (Created) with an oauth token like below and sets a
+JWT_FGP cookie.
+{
+  "access_token": "<about 1500 characters of base64>",
+  "token_type": "bearer",
+  "refresh_token": "<about 150 characters of base64>",
+  "expires_in": 3599,
+  "scope": "..",
+  "jti": "81458bbb-c4d9-4fdc-b08c-ac0327f82db9",
+  "refresh_token_expires_in": 7199
+}
+"""
+
+ENTER_MFA_CODE_URL = "https://sso.garmin.com/sso/verifyMFA/loginEnterMfaCode"
+"""For users with multi-factor authentication enabled, this is the URL where
+the MFA code (sent by Garmin to the user) should be verified."""
+
+SIGNIN_PARAMS = {
+    'id':                              'gauth-widget',
+    'embedWidget':                     'true',
+    'clientId':                        'GarminConnect',
+    'gauthHost':                       SSO_EMBED_URL,
+    'service':                         SSO_EMBED_URL,
+    'source':                          SSO_EMBED_URL,
+    'redirectAfterAccountLoginUrl':    SSO_EMBED_URL,
+    'redirectAfterAccountCreationUrl': SSO_EMBED_URL}
+"""Query parameters to use for login atttempts against SSO_SIGNIN_URL."""
+
+
+def mfa_code_prompt() -> str:
+    """Prompts the user to enter an Multi-Factor Authentication code."""
+    return input('Enter MFA code sent to you> ')
+
+
+def ensure_authenticated(client_function):
+    """Decorator that is used to annotate any GarminClient method that needs an
+    authenticated session before being called.
+    """
+    @wraps(client_function)
+    def ensure_session(*args, **kwargs):
+        """Sets an authenticated session attribute for the calling GarminClient
+        object."""
+        client_object = args[0]  # The calling GarminClient object.
+        # Sanity checks.
+        if not hasattr(client_object, 'authenticator'):
+            raise Exception('GarminClient missing "authenticator" attribute')
+        if not hasattr(client_object, 'session'):
+            raise Exception('GarminClient missing "session" attribute')
+
+        # Clean up any prior session.
+        if client_object.session:
+            client_object.session.close()
+        # Ensure an authenticated session prior to making the method call.
+        session = client_object.authenticator.ensure_authenticated_session()
+        client_object.session = session
+        return client_function(*args, **kwargs)
+
+    return ensure_session
+
+
+class Authenticator(object):
+    """Authenticator is intended to be configured for a GarminClient to prepare
+    an authenticated session prior to making method calls annotated with the
+    `@ensure_authenticated` decorator.
+
+    That will ensure a session is used with with proper headers (notably
+    `Authorization`, `Di-Backend`, and `NK`) and cookies (notably `JWT_FGP`).
+    """
+
+    def __init__(self, token_store: TokenStore, username: str, password: str,
+                 mfa_code_supplier: Callable[[], str] = mfa_code_prompt):
+        self.token_store = token_store
+        self.username = username
+        self.password = password
+        self.mfa_code_prompt = mfa_code_prompt
+
+    def ensure_authenticated_session(self) -> Session:
+        """Returns a Session with authentication headers and cookies."""
+        oauth_tok, jwt_cookie = self._ensure_tokens()
+        # If the token is close to expiry we need to refresh it.
+        oauth_tok = self._ensure_fresh(oauth_tok, jwt_cookie)
+
+        # Prepare an authenticated session with headers and cookies.
+        authenticated_session = requests.Session()
+        authenticated_session.headers.update({
+            'Authorization': '{} {}'.format(
+                oauth_tok.token_type(), oauth_tok.access_token()),
+            'Di-Backend': 'connectapi.garmin.com',
+            'NK': 'NT'})
+        authenticated_session.cookies.set(
+            'JWT_FGP', self.token_store.get_jwt_fgp_cookie())
+        return authenticated_session
+
+    def _ensure_tokens(self) -> (OAuthToken, JwtFgpCookie):
+        if self.token_store.has_fresh_tokens():
+            log.debug("reusing existing oauth token found in token store ...")
+            return self.token_store.get_oauth_token(), self.token_store.get_jwt_fgp_cookie()
+
+        log.debug("no fresh oauth token found, acquiring new ...")
+        oauth_token, jwt_fgp_cookie = self._acquire_tokens()
+        # Save in token_store
+        log.debug("saving acquired oauth token in token store ...")
+        self.token_store.set_oauth_token(oauth_token)
+        self.token_store.set_jwt_fgp_cookie(jwt_fgp_cookie)
+        return oauth_token, jwt_fgp_cookie
+
+    def _ensure_fresh(self, token: OAuthToken, jwt_cookie: JwtFgpCookie) \
+            -> OAuthToken:
+        if token.time_to_expiry() > 60:
+            log.debug("access_token still fresh (expires in %.1f seconds)",
+                      token.time_to_expiry())
+            return token
+        # Refresh auth token and save in token store.
+        log.debug("refreshing oauth token (expires in %.1f seconds) ...",
+                  token.time_to_expiry())
+        headers = {
+            'Authorization': f'{token.token_type()} {token.access_token()}',
+            'Di-Backend': 'connectapi.garmin.com',
+            'NK': 'NT'}
+        resp = requests.post(AUTH_TOKEN_REFRESH_URL,
+                             cookies={'JWT_FGP': jwt_cookie}, headers=headers,
+                             json={'refresh_token': token.refresh_token()})
+        if resp.status_code != 201:
+            raise ValueError(f'refresh oauth token: {resp.status_code}: '
+                             f'{resp.text}')
+        new_token = OAuthToken(resp.json(), age_s=0)
+        jwt_fgp_cookie = resp.cookies['JWT_FGP']
+        # Save in token store.
+        log.debug("saving refreshed oauth token ...")
+        self.token_store.set_oauth_token(new_token)
+        self.token_store.set_jwt_fgp_cookie(jwt_fgp_cookie)
+        return new_token
+
+    def _acquire_tokens(self) -> (OAuthToken, JwtFgpCookie):
+        log.debug("acquiring authentication tokens ...")
+        auth_client = requests.Session()
+        cas_ticket = self._login(auth_client, self.username, self.password)
+        log.debug("got CAS ticket: %s", cas_ticket)
+        self._validate_cas_ticket(auth_client, cas_ticket)
+        return self._fetch_oauth_token(auth_client)
+
+    def _login(self, auth_client: Session, username, password: str) \
+            -> CASTicket:
+        log.debug("logging in ...")
+        # Set cookies.
+        log.debug("log in: calling sso/embed to set cookies ...")
+        resp = auth_client.get(SSO_EMBED_URL, params={
+            'embedWidget': 'true',
+            'gauthHost': 'https://sso.garmin.com/sso',
+            'id': 'gauth-widget'})
+        require_status(resp, 200)
+        # Get CSRF token.
+        csrf_token = self._get_csrf_token(auth_client)
+        # Submit login form
+        ticket = self._get_login_auth_ticket(auth_client, csrf_token)
+        return ticket
+
+    def _validate_cas_ticket(self, auth_client: Session, ticket: CASTicket):
+        """Validates a CAS authentication ticket
+        ("ST-01055566-3753GCopsoOm6yWrrXro-cas") granted from a prior login
+        form submission."""
+        log.debug("validating CAS ticket %s ...", ticket)
+        auth_client.get('https://connect.garmin.com/modern/', headers={},
+                        params={'ticket': ticket})
+
+    def _fetch_oauth_token(self, auth_client: Session) -> \
+            (OAuthToken, JwtFgpCookie):
+        log.debug("exchanging CAS ticket for OAuth token ...")
+        headers = {
+            'authority': 'connect.garmin.com',
+            'origin': 'https://connect.garmin.com',
+            'referer': 'https://connect.garmin.com/modern/'}
+        resp = auth_client.post(OAUTH_EXCHANGE_URL, headers=headers)
+        require_status(resp, 200)
+        token = OAuthToken(resp.json(), 0)
+        return token, auth_client.cookies['JWT_FGP']
+
+    def _get_csrf_token(self, auth_client: Session) -> str:
+        resp = auth_client.get(SSO_SIGNIN_URL, params=SIGNIN_PARAMS)
+        require_status(resp, 200)
+        return find_page_csrf_token(resp.text)
+
+    def _get_login_auth_ticket(self, auth_client: Session, csrf_token: str) \
+            -> CASTicket:
+        form_data = dict(username=self.username, password=self.password,
+                         embed="true", _csrf=csrf_token)
+        form_headers = {
+            'Content-Type': 'application/x-www-form-urlencoded',
+            'Referer': SSO_SIGNIN_URL}
+        log.debug("using CSRF token for signin page: '%s'", csrf_token)
+        resp = auth_client.post(SSO_SIGNIN_URL, headers=form_headers,
+                                params=SIGNIN_PARAMS, data=form_data)
+        if resp.status_code == 429:
+            # CloudFlare blocked us. Retry in one hour.
+            raise ValueError(
+                'Authentication attempt gave 429 (Too Many Requests). '
+                'You are being rate limited. Please back off.')
+        title = get_page_title(resp.text)
+        log.debug("got login page response:\n%s", resp.text)
+        # Note: if the account has multi-factor authentication enabled an MFA
+        # code will be sent to the user (as SMS or email, depending on user
+        # settings).
+        if title == "Enter MFA code for login":
+            csrf_token = find_page_csrf_token(resp.text)
+            mfa_code = self.mfa_code_prompt()
+            log.debug("using CSRF token for mfa verification page: '%s'", csrf_token)
+            log.debug("using MFA code: '%s'", csrf_token)
+            resp = self._verify_mfa_code(auth_client, csrf_token, mfa_code)
+            title = get_page_title(resp.text)
+        if title != "Success":
+            raise ValueError(f'auth attempt failed with {resp.status_code}: '
+                             f'{resp.text}')
+        m = re.search(r'ticket=(ST-[^"]+)', resp.text)
+        if not m:
+            raise ValueError(f'no ticket found in {SSO_SIGNIN_URL} response')
+        ticket = m.group(1)
+        return ticket
+
+    def _verify_mfa_code(self, auth_client: Session, csrf_token: str,
+                         mfa_code: str) -> requests.Response:
+        form_data = {"mfa-code": mfa_code, "embed": "true",
+                     "_csrf": csrf_token, "fromPage": "setupEnterMfaCode"}
+        headers = {'referer': SSO_SIGNIN_URL}
+        resp = auth_client.post(ENTER_MFA_CODE_URL, params=SIGNIN_PARAMS,
+                                data=form_data, headers=headers)
+        log.debug("verify MFA response: %d:\n%s", resp.status_code, resp.text)
+        return resp
+
+
+def require_status(resp: requests.Response, want_code: int):
+    """Raises an error unless the response has a given HTTP status code."""
+    if resp.status_code != want_code:
+        raise ValueError(
+            f'{resp.request.method} {resp.request.url} '
+            f'gave {resp.status_code} (wanted {want_code}): {resp.text}')
+
+
+TITLE_RE = re.compile(r"<title>(.+?)</title>")
+"""Regular expression used to capture the page title when submitting a login
+form to SSO_SIGNIN_URL."""
+
+
+def get_page_title(html: str) -> str:
+    """Retrieve the title element from a HTML page."""
+    m = TITLE_RE.search(html)
+    if not m:
+        raise ValueError("couldn't find page title")
+    return m.group(1)
+
+
+CSRF_RE = re.compile(r'name="_csrf"\s+value="(?P<token>.+?)"')
+"""Regular expression used to capture the CSRF token from the SSO_SIGNIN_URL
+page."""
+
+
+def find_page_csrf_token(html: str) -> str:
+    m = CSRF_RE.search(html)
+    if not m:
+        raise ValueError('no CSRF token found in page')
+    csrf_token = m.group('token')
+    return csrf_token

--- a/garminexport/cli/backup.py
+++ b/garminexport/cli/backup.py
@@ -7,6 +7,8 @@ backup directory will be downloaded.
 import argparse
 import logging
 import os
+from pathlib import Path
+import traceback
 
 from garminexport.backup import supported_export_formats
 from garminexport.incremental_backup import incremental_backup
@@ -15,8 +17,13 @@ from garminexport.logging_config import LOG_LEVELS
 logging.basicConfig(level=logging.INFO, format="%(asctime)-15s [%(levelname)s] %(message)s")
 log = logging.getLogger(__name__)
 
-DEFAULT_MAX_RETRIES = 7
+DEFAULT_MAX_RETRIES = 3
 """The default maximum number of retries to make when fetching a single activity."""
+
+DEFAULT_AUTH_TOKEN_DIR = os.path.join(Path.home(), '.garminexport')
+"""File where acquired authentication tokens are saved for later reuse.
+This often allows us to bypass the login step, which is prone to rate-limiting."""
+
 
 def parse_args() -> argparse.Namespace:
     """Parse CLI arguments.
@@ -41,6 +48,10 @@ def parse_args() -> argparse.Namespace:
         "--backup-dir", metavar="DIR", type=str,
         help="Destination directory for downloaded activities. Default: ./activities/",
         default=os.path.join(".", "activities"))
+    parser.add_argument(
+        "--auth-token-dir", metavar="DIR", type=str,
+        help=f"Directory where tokens from successful authentication are saved for later reuse. Default: {DEFAULT_AUTH_TOKEN_DIR}",
+        default=DEFAULT_AUTH_TOKEN_DIR)
     parser.add_argument(
         "--log-level", metavar="LEVEL", type=str,
         help="Desired log output level (DEBUG, INFO, WARNING, ERROR). Default: INFO.",
@@ -69,10 +80,13 @@ def main():
     try:
         incremental_backup(username=args.username,
                            password=args.password,
+                           auth_token_dir=args.auth_token_dir,
                            backup_dir=args.backup_dir,
                            export_formats=args.format,
                            ignore_errors=args.ignore_errors,
                            max_retries=args.max_retries)
 
     except Exception as e:
-        log.error("failed with exception: {}".format(e))
+        log.error(str(e))
+        if args.log_level == 'DEBUG':
+            print(traceback.format_exc())

--- a/garminexport/garminclient.py
+++ b/garminexport/garminclient.py
@@ -6,7 +6,6 @@ from builtins import range
 from datetime import timedelta, datetime
 import dateutil
 import dateutil.parser
-from functools import partial, wraps
 from io import BytesIO
 import json
 import logging
@@ -16,7 +15,13 @@ import requests
 import sys
 import zipfile
 
-from garminexport.retryer import Retryer, ExponentialBackoffDelayStrategy, MaxRetriesStopStrategy
+from garminexport.authenticator import (Authenticator,
+                                        ensure_authenticated,
+                                        require_status)
+from garminexport.retryer import (Retryer,
+                                  ExponentialBackoffDelayStrategy,
+                                  MaxRetriesStopStrategy)
+from garminexport.token_store import TokenStore
 
 
 log = logging.getLogger(__name__)
@@ -24,257 +29,106 @@ log = logging.getLogger(__name__)
 logging.getLogger("requests").setLevel(logging.ERROR)
 
 
-PORTAL_LOGIN_URL = "https://sso.garmin.com/portal/api/login"
-"""Garmin Connect's Single-Sign On login URL."""
-SSO_LOGIN_URL = "https://sso.garmin.com/sso/login"
-"""Garmin Connect's Single-Sign On login URL."""
-SSO_SIGNIN_URL = "https://sso.garmin.com/sso/signin"
-"""The Garmin Connect Single-Sign On sign-in URL. This is where the login form
-gets POSTed."""
-
-
-def require_session(client_function):
-    """Decorator that is used to annotate :class:`GarminClient`
-    methods that need an authenticated session before being called.
-    """
-
-    @wraps(client_function)
-    def check_session(*args, **kwargs):
-        client_object = args[0]
-        if not client_object.session:
-            raise Exception("Attempt to use GarminClient without being connected. Call connect() before first use.'")
-        return client_function(*args, **kwargs)
-
-    return check_session
-
-
 class GarminClient(object):
-    """A client class used to authenticate with Garmin Connect and
-    extract data from the user account.
+    """A client class used to authenticate with Garmin Connect and extract data
+    from the user account.
 
-    Since this class implements the context manager protocol, this object
-    can preferably be used together with the with-statement. This will
-    automatically take care of logging in to Garmin Connect before any
-    further interactions and logging out after the block completes or
-    a failure occurs.
+    Any client method with the `ensure_authenticated` decorator will make sure
+    that the client uses a fresh OAuth token (and session cookies) for
+    authentication.
 
-    Example of use: ::
-      with GarminClient("my.sample@sample.com", "secretpassword") as client:
+    The connect method can also be called separately to establish an
+    authenticated session. This might be useful to verify client credentials in
+    isolation.
+
+    When the client is no longer needed the disconnect method should be called
+    to reclaim system resources.
+
+    Example of use:
+
+      try:
+          client = GarminClient("<username>", "<password>", ".garminexport")
+          client.connect()
           ids = client.list_activity_ids()
-          for activity_id in ids:
-               gpx = client.get_activity_gpx(activity_id)
+              for activity_id in ids:
+                  gpx = client.get_activity_gpx(activity_id)
+      finally:
+          client.disconnect()
 
     """
 
-    def __init__(self, username, password):
+    def __init__(self, username: str, password: str, auth_token_dir: str):
         """Initialize a :class:`GarminClient` instance.
 
         :param username: Garmin Connect user name or email address.
-        :type username: str
         :param password: Garmin Connect account password.
-        :type password: str
+        :param auth_token_dir: Folder where authentication tokens from
+          successful logins are stored. If this directory exists and contains a
+          sufficiently fresh OAuth token it will be reused. Otherwise a new
+          login attempt is made and, if successful, the OAuth token gets
+          written to the folder.
         """
-        self.username = username
-        self.password = password
-
+        self.authenticator = Authenticator(TokenStore(auth_token_dir),
+                                           username, password)
         self.session = None
 
-
-    def __enter__(self):
-        self.connect()
-        return self
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        self.disconnect()
-
     def connect(self):
-        self.session = new_http_session()
-        self._authenticate()
+        """Ensures an authenticated Garmin Connect session."""
+        if not self.session:
+            self.session = self.authenticator.ensure_authenticated_session()
 
     def disconnect(self):
+        """Drops the current session if one is active."""
         if self.session:
             self.session.close()
             self.session = None
 
-    def _authenticate(self):
-        """
-        Authenticates using a Garmin Connect username and password.
-
-        The procedure has changed over the years. A good approach for figuring
-        it out is to use the browser development tools to trace all requests
-        following a sign-in.
-        """
-        log.info("authenticating user ...")
-
-        auth_ticket_url = self._login(self.username, self.password)
-        log.debug("auth ticket url: '%s'", auth_ticket_url)
-
-        self._claim_auth_ticket(auth_ticket_url)
-
-        # we need to touch base with the main page to complete the login ceremony.
-        self.session.get('https://connect.garmin.com/modern')
-        # This header appears to be needed on subsequent session requests or we
-        # end up with a 402 response from Garmin.
-        self.session.headers.update({'NK': 'NT'})
-
-        # We need to pass an Authorization oauth token with subsequent requests.
-        auth_token = self._get_oauth_token()
-        token_type = auth_token['token_type']
-        access_token = auth_token['access_token']
-        self.session.headers.update(
-            {
-                'Authorization': f'{token_type} {access_token}',
-                'Di-Backend': 'connectapi.garmin.com',
-            })
-
-
-    def _get_oauth_token(self):
-        """Retrieve an OAuth token to use for the session.
-
-        Typically looks something like the following. The 'access_token'
-        needs to be passed in the 'Authorization' header for remaining session
-        requests.
-
-          {
-            "scope": "...",
-            "jti": "...",
-            "access_token": "...",
-            "token_type": "Bearer",
-            "refresh_token": "...",
-            "expires_in": 3599,
-            "refresh_token_expires_in": 7199
-          }
-        """
-        log.info("getting oauth token ...")
-        headers = {
-            'authority': 'connect.garmin.com',
-            'origin': 'https://connect.garmin.com',
-            'referer': 'https://connect.garmin.com/modern/',
-        }
-        resp = self.session.post('https://connect.garmin.com/modern/di-oauth/exchange',
-                                 headers=headers)
-        if resp.status_code != 200:
-            raise ValueError(f'get oauth token failed with {resp.status_code}: {resp.text}')
-        return resp.json()
-
-
-    def _login(self, username, password):
-        """Logs in with the supplied account credentials.
-        The return value is a URL where the created authentication ticket can be claimed.
-        For example, "https://connect.garmin.com/modern?ticket=ST-2550833-30KdiEJ3jqvFzLNGi2C7-sso"
-
-        The response message looks typically something like this:
-          {
-             "serviceURL":"https://connect.garmin.com/modern/",
-             "serviceTicketId":"ST-2550833-30KdiEJ3jqvFzLNGi2C7-sso",
-             "responseStatus":{"type":"SUCCESSFUL","message":"","httpStatus":"OK"},
-             "customerMfaInfo":null,
-             "consentTypeList":null
-          }
-        """
-        headers = {
-            'authority': 'sso.garmin.com',
-            'origin': 'https://sso.garmin.com',
-            'referer': 'https://sso.garmin.com/portal/sso/en-US/sign-in?clientId=GarminConnect&service=https%3A%2F%2Fconnect.garmin.com%2Fmodern',
-        }
-        params = {
-            "clientId": "GarminConnect",
-            "service": "https://connect.garmin.com/modern/",
-            "gauthHost": "https://sso.garmin.com/sso",
-        }
-        form_data = {'username': username, 'password': password}
-
-        log.info("passing login credentials ...")
-        resp = self.session.post(PORTAL_LOGIN_URL, headers=headers, params=params, json=form_data)
-        log.debug("got auth response %d: %s", resp.status_code, resp.text)
-        if resp.status_code != 200:
-            raise ValueError(f'authentication attempt failed with {resp.status_code}: {resp.text}')
-        return self._extract_auth_ticket_url(resp.json())
-
-    def _claim_auth_ticket(self, auth_ticket_url):
-        # Note: first we bump the login URL.
-        p = {
-            'clientId': 'GarminConnect',
-            'service': 'https://connect.garmin.com/modern/',
-            'webhost': 'https://connect.garmin.com',
-            'gateway': 'true',
-            'generateExtraServiceTicket': 'true',
-            'generateTwoExtraServiceTickets': 'true',
-        }
-        self.session.get(SSO_LOGIN_URL, headers={}, params=p)
-
-        log.info("claiming auth ticket %s ...", auth_ticket_url)
-        response = self.session.get(auth_ticket_url)
-        if response.status_code != 200:
-            raise RuntimeError(
-                "auth failure: failed to claim auth ticket: {}: {}\n{}".format(
-                    auth_ticket_url, response.status_code, response.text))
-
-
-    @staticmethod
-    def _extract_auth_ticket_url(auth_response):
-        """Extracts an authentication ticket URL from the response of an
-        authentication form submission. The auth ticket URL is typically
-        of form:
-
-          https://connect.garmin.com/modern?ticket=ST-0123456-aBCDefgh1iJkLmN5opQ9R-cas
-
-        :param auth_response: JSON response from a login form submission.
-        """
-        if auth_response['responseStatus']['type'] == 'INVALID_USERNAME_PASSWORD':
-            RuntimeError("authentication failure: did you provide a correct username/password?")
-        service_url = auth_response.get('serviceURL')
-        auth_ticket = auth_response.get('serviceTicketId')
-        if not service_url:
-            raise RuntimeError("auth failure: unable to extract serviceURL")
-        if not auth_ticket:
-            raise RuntimeError("auth failure: unable to extract serviceTicketId")
-        auth_ticket_url = service_url.rstrip('/') + '?ticket=' + auth_ticket
-        return auth_ticket_url
-
-    @require_session
-    def list_activities(self):
+    @ensure_authenticated
+    def list_activities(self) -> list[(int, datetime)]:
         """Return all activity ids stored by the logged in user, along
         with their starting timestamps.
 
-        :returns: The full list of activity identifiers (along with their starting timestamps).
-        :rtype: tuples of (int, datetime)
+        :returns: The full list of activity identifiers (along with their
+          starting timestamps).
         """
         ids = []
         batch_size = 100
         # fetch in batches since the API doesn't allow more than a certain
         # number of activities to be retrieved on every invocation
         for start_index in range(0, sys.maxsize, batch_size):
-            next_batch = self._fetch_activity_ids_and_ts(start_index, batch_size)
+            next_batch = self._fetch_activity_ids_and_ts(
+                start_index, batch_size)
             if not next_batch:
                 break
             ids.extend(next_batch)
         return ids
 
-    @require_session
-    def _fetch_activity_ids_and_ts(self, start_index, max_limit=100):
+    @ensure_authenticated
+    def _fetch_activity_ids_and_ts(self, start_index, max_limit: int = 100) \
+            -> (int, datetime):
         """Return a sequence of activity ids (along with their starting
         timestamps) starting at a given index, with index 0 being the user's
         most recently registered activity.
 
-        Should the index be out of bounds or the account empty, an empty list is returned.
+        Should the index be out of bounds or the account empty, an empty list
+        is returned.
 
         :param start_index: The index of the first activity to retrieve.
-        :type start_index: int
         :param max_limit: The (maximum) number of activities to retrieve.
-        :type max_limit: int
 
         :returns: A list of activity JSON dicts describing the activity
-        :rtype: tuples of (int, datetime)
         """
-        log.debug("fetching activities %d through %d ...", start_index, start_index + max_limit - 1)
+        log.debug("fetching activities %d through %d ...",
+                  start_index, start_index + max_limit - 1)
         response = self.session.get(
             "https://connect.garmin.com/activitylist-service/activities/search/activities",
             params={"start": start_index, "limit": max_limit})
         if response.status_code != 200:
             raise Exception(
                 u"failed to fetch activities {} to {} types: {}\n{}".format(
-                    start_index, (start_index + max_limit - 1), response.status_code, response.text))
+                    start_index, (start_index + max_limit - 1),
+                    response.status_code,
+                    response.text))
         activities = json.loads(response.text)
         if not activities:
             # index out of bounds or empty account
@@ -290,60 +144,52 @@ class GarminClient(object):
         log.debug("got %d activities.", len(entries))
         return entries
 
-    @require_session
-    def get_activity_summary(self, activity_id):
-        """Return a summary about a given activity.
-        The summary contains several statistics, such as duration, GPS starting
-        point, GPS end point, elevation gain, max heart rate, max pace, max speed, etc).
+    @ensure_authenticated
+    def get_activity_summary(self, activity_id: int) -> dict:
+        """Return a summary about a given activity. The summary contains
+        several statistics, such as duration, GPS starting point, GPS end
+        point, elevation gain, max heart rate, max pace, max speed, etc).
 
         :param activity_id: Activity identifier.
-        :type activity_id: int
         :returns: The activity summary as a JSON dict.
-        :rtype: dict
+
         """
         response = self.session.get(
-            "https://connect.garmin.com/activity-service/activity/{}".format(activity_id))
-        if response.status_code != 200:
-            log.error(u"failed to fetch json summary for activity %s: %d\n%s",
-                      activity_id, response.status_code, response.text)
-            raise Exception(u"failed to fetch json summary for activity {}: {}\n{}".format(
-                activity_id, response.status_code, response.text))
+            "https://connect.garmin.com/activity-service/activity/{}".
+            format(activity_id))
+        require_status(response, 200)
         return json.loads(response.text)
 
-    @require_session
-    def get_activity_details(self, activity_id):
+    @ensure_authenticated
+    def get_activity_details(self, activity_id: int) -> dict:
         """Return a JSON representation of a given activity including
         available measurements such as location (longitude, latitude),
         heart rate, distance, pace, speed, elevation.
 
         :param activity_id: Activity identifier.
-        :type activity_id: int
         :returns: The activity details as a JSON dict.
-        :rtype: dict
         """
         # mounted at xml or json depending on result encoding
         response = self.session.get(
-            "https://connect.garmin.com/activity-service/activity/{}/details".format(activity_id))
-        if response.status_code != 200:
-            raise Exception(u"failed to fetch json activityDetails for {}: {}\n{}".format(
-                activity_id, response.status_code, response.text))
+            "https://connect.garmin.com/activity-service/activity/{}/details".
+            format(activity_id))
+        require_status(response, 200)
         return json.loads(response.text)
 
-    @require_session
-    def get_activity_gpx(self, activity_id):
+    @ensure_authenticated
+    def get_activity_gpx(self, activity_id: int) -> str:
         """Return a GPX (GPS Exchange Format) representation of a
         given activity. If the activity cannot be exported to GPX
         (not yet observed in practice, but that doesn't exclude the
         possibility), a :obj:`None` value is returned.
 
         :param activity_id: Activity identifier.
-        :type activity_id: int
         :returns: The GPX representation of the activity as an XML string
           or ``None`` if the activity couldn't be exported to GPX.
-        :rtype: str
         """
         response = self.session.get(
-            "https://connect.garmin.com/download-service/export/gpx/activity/{}".format(activity_id))
+            "https://connect.garmin.com/download-service/export/gpx/activity/{}"
+            .format(activity_id))
         # An alternate URL that seems to produce the same results
         # and is the one used when exporting through the Garmin
         # Connect web page.
@@ -354,13 +200,11 @@ class GarminClient(object):
         # example be a manually entered activity without any device data.
         if response.status_code in (404, 204):
             return None
-        if response.status_code != 200:
-            raise Exception(u"failed to fetch GPX for activity {}: {}\n{}".format(
-                activity_id, response.status_code, response.text))
+        require_status(response, 200)
         return response.text
 
-    @require_session
-    def get_activity_tcx(self, activity_id):
+    @ensure_authenticated
+    def get_activity_tcx(self, activity_id: int) -> str:
         """Return a TCX (Training Center XML) representation of a
         given activity. If the activity doesn't have a TCX source (for
         example, if it was originally uploaded in GPX format, Garmin
@@ -368,35 +212,31 @@ class GarminClient(object):
         returned.
 
         :param activity_id: Activity identifier.
-        :type activity_id: int
         :returns: The TCX representation of the activity as an XML string
           or ``None`` if the activity cannot be exported to TCX.
-        :rtype: str
         """
 
         response = self.session.get(
-            "https://connect.garmin.com/download-service/export/tcx/activity/{}".format(activity_id))
+            "https://connect.garmin.com/download-service/export/tcx/activity/{}"
+            .format(activity_id))
         if response.status_code == 404:
             return None
-        if response.status_code != 200:
-            raise Exception(u"failed to fetch TCX for activity {}: {}\n{}".format(
-                activity_id, response.status_code, response.text))
+        require_status(response, 200)
         return response.text
 
-    def get_original_activity(self, activity_id):
+    def get_original_activity(self, activity_id: int) -> (str, str):
         """Return the original file that was uploaded for an activity.
         If the activity doesn't have any file source (for example,
         if it was entered manually rather than imported from a Garmin
         device) then :obj:`(None,None)` is returned.
 
         :param activity_id: Activity identifier.
-        :type activity_id: int
         :returns: A tuple of the file type (e.g. 'fit', 'tcx', 'gpx') and
           its contents, or :obj:`(None,None)` if no file is found.
-        :rtype: (str, str)
         """
         response = self.session.get(
-            "https://connect.garmin.com/download-service/files/activity/{}".format(activity_id))
+            "https://connect.garmin.com/download-service/files/activity/{}"
+            .format(activity_id))
         # A 404 (Not Found) response is a clear indicator of a missing .fit
         # file. As of lately, the endpoint appears to have started to
         # respond with 500 "NullPointerException" on attempts to download a
@@ -404,10 +244,7 @@ class GarminClient(object):
         if response.status_code in [404, 500]:
             # Manually entered activity, no file source available
             return None, None
-        if response.status_code != 200:
-            raise Exception(
-                u"failed to get original activity file for {}: {}\n{}".format(
-                    activity_id, response.status_code, response.text))
+        require_status(response, 200)
 
         # return the first entry from the zip archive where the filename is
         # activity_id (should be the only entry!)
@@ -418,7 +255,7 @@ class GarminClient(object):
                 return ext[1:], zip_file.open(path).read()
         return None, None
 
-    def get_activity_fit(self, activity_id):
+    def get_activity_fit(self, activity_id: int) -> str:
         """Return a FIT representation for a given activity. If the activity
         doesn't have a FIT source (for example, if it was entered manually
         rather than imported from a Garmin device) a :obj:`None` value is
@@ -428,7 +265,6 @@ class GarminClient(object):
         :type activity_id: int
         :returns: A string with a FIT file for the activity or :obj:`None`
           if no FIT source exists for this activity (e.g., entered manually).
-        :rtype: str
         """
         fmt, orig_file = self.get_original_activity(activity_id)
         # if the file extension of the original activity file isn't 'fit',
@@ -436,24 +272,21 @@ class GarminClient(object):
         # and cannot be exported to fit
         return orig_file if fmt == 'fit' else None
 
-    @require_session
-    def _poll_upload_completion(self, uuid, creation_date):
+    @ensure_authenticated
+    def _poll_upload_completion(self, uuid: str, creation_date: str) -> int:
         """Poll for completion of an upload. If Garmin connect returns
         HTTP status 202 ("Accepted") after initial upload, then we must poll
         until the upload has either succeeded or failed. Raises an
         :class:`Exception` if the upload has failed.
 
         :param uuid: uploadUuid returned on initial upload.
-        :type uuid: str
         :param creation_date: creationDate returned from initial upload (e.g.
           "2020-01-01 12:34:56.789 GMT")
-        :type creation_date: str
         :returns: Garmin's internalId for the newly-created activity, or
           :obj:`None` if upload is still processing.
-        :rtype: int
         """
         response = self.session.get("https://connect.garmin.com/proxy/activity-service/activity/status/{}/{}?_={}".format(
-            creation_date[:10], uuid.replace("-",""), int(datetime.now().timestamp()*1000)), headers={"nk": "NT"})
+            creation_date[:10], uuid.replace("-",""), int(datetime.now().timestamp() * 1000)), headers={"nk": "NT"})
         if response.status_code == 201 and response.headers["location"]:
             # location should be https://connectapi.garmin.com/activity-service/activity/ACTIVITY_ID
             return int(response.headers["location"].split("/")[-1])
@@ -462,25 +295,21 @@ class GarminClient(object):
         else:
             response.raise_for_status()
 
-    @require_session
-    def upload_activity(self, file, format=None, name=None, description=None, activity_type=None, private=None):
+    @ensure_authenticated
+    def upload_activity(self, file: str, format: str = None, name: str = None, \
+                        description: str = None, activity_type: str = None, \
+                        private: bool = None) -> int:
         """Upload a GPX, TCX, or FIT file for an activity.
 
         :param file: Path or open file
-        :param format: File format (gpx, tcx, or fit); guessed from filename if :obj:`None`
-        :type format: str
+        :param format: File format (gpx, tcx, fit); guessed from file if None.
         :param name: Optional name for the activity on Garmin Connect
-        :type name: str
-        :param description: Optional description for the activity on Garmin Connect
-        :type description: str
-        :param activity_type: Optional activityType key (lowercase: e.g. running, cycling)
-        :type activityType: str
+        :param description: Optional description for the activity.
+        :param activity_type: Optional activityType key (lowercase: e.g.
+          running, cycling)
         :param private: If true, then activity will be set as private.
-        :type private: bool
         :returns: ID of the newly-uploaded activity
-        :rtype: int
         """
-
         if isinstance(file, str):
             file = open(file, "rb")
 
@@ -555,24 +384,3 @@ class GarminClient(object):
                     activity_id, response.status_code, response.text))
 
         return activity_id
-
-
-def new_http_session():
-    """Returns a requests-compatible HTTP Session.
-    See https://requests.readthedocs.io/en/latest/user/advanced/#session-objects.
-
-    By default it uses the requests library to create http sessions. If built with
-    the 'impersonate-browser' extra, it will use curl_cffi and a patched libcurl to
-    produce identical TLS fingerprints as a real web browsers to circumvent
-    Cloudflare's bot protection.
-    """
-    session_factory_func = requests.session
-    try:
-        import curl_cffi.requests
-        # For supported browsers: see https://github.com/lwthiker/curl-impersonate#supported-browsers
-        browser = os.getenv("GARMINEXPORT_IMPERSONATE_BROWSER", "chrome110")
-        log.info("using 'curl_cffi' to create HTTP sessions that impersonate web browser '%s' ...", browser)
-        session_factory_func = partial(curl_cffi.requests.Session, impersonate=browser)
-    except (ImportError):
-        pass
-    return session_factory_func()

--- a/garminexport/incremental_backup.py
+++ b/garminexport/incremental_backup.py
@@ -2,42 +2,60 @@
 import getpass
 import logging
 import os
-from datetime import timedelta
-from typing import Callable, List
+from typing import List
 
 import garminexport.backup
 from garminexport.backup import supported_export_formats
 from garminexport.garminclient import GarminClient
-from garminexport.retryer import Retryer, ExponentialBackoffDelayStrategy, MaxRetriesStopStrategy
+from garminexport.retryer import (Retryer,
+                                  ExponentialBackoffDelayStrategy,
+                                  MaxRetriesStopStrategy)
 
 log = logging.getLogger(__name__)
 
 
 def incremental_backup(username: str,
                        password: str = None,
+                       auth_token_dir: str = None,
                        backup_dir: str = os.path.join(".", "activities"),
                        export_formats: List[str] = None,
                        ignore_errors: bool = False,
                        max_retries: int = 7):
-    """Performs (incremental) backups of activities for a given Garmin Connect account.
+    """Performs (incremental) backups of activities for a given Garmin Connect
+    account.
 
     :param username: Garmin Connect user name
-    :param password: Garmin Connect user password. Default: None. If not provided, would be asked interactively.
-    :param backup_dir: Destination directory for downloaded activities. Default: ./activities/".
-    :param export_formats: List of desired output formats (json_summary, json_details, gpx, tcx, fit).
-    Default: `None` which means all supported formats will be backed up.
-    :param ignore_errors: Ignore errors and keep going. Default: False.
-    :param max_retries: The maximum number of retries to make on failed attempts to fetch an activity.
-    Exponential backoff will be used, meaning that the delay between successive attempts
-    will double with every retry, starting at one second. Default: 7.
 
-    The activities are stored in a local directory on the user's computer.
-    The backups are incremental, meaning that only activities that aren't already
+    :param password: Garmin Connect user password. Default: None. If not
+    provided, would be asked interactively.
+
+    :param auth_token_dir: Folder where authentication tokens from successful
+    logins are stored. If this directory exists and contains a sufficiently
+    fresh OAuth token it will be reused. Otherwise a new login attempt is made
+    and, if successful, the OAuth token gets written to the folder.
+
+    :param backup_dir: Destination directory for downloaded
+    activities. Default: ./activities/".
+
+    :param export_formats: List of desired output formats (json_summary,
+    json_details, gpx, tcx, fit).  Default: `None` which means all supported
+    formats will be backed up.
+
+    :param ignore_errors: Ignore errors and keep going. Default: False.
+
+    :param max_retries: The maximum number of retries to make on failed
+    attempts to fetch an activity.  Exponential backoff will be used, meaning
+    that the delay between successive attempts will double with every retry,
+    starting at one second. Default: 7.
+
+    The activities are stored in a local directory on the user's computer.  The
+    backups are incremental, meaning that only activities that aren't already
     stored in the backup directory will be downloaded.
 
     """
     # if no --format was specified, all formats are to be backed up
-    export_formats = export_formats if export_formats else supported_export_formats
+    export_formats = export_formats if export_formats \
+        else supported_export_formats
     log.info("backing up formats: %s", ", ".join(export_formats))
 
     if not os.path.isdir(backup_dir):
@@ -48,10 +66,13 @@ def incremental_backup(username: str,
 
     # set up a retryer that will handle retries of failed activity downloads
     retryer = Retryer(
-        delay_strategy=ExponentialBackoffDelayStrategy(initial_delay=timedelta(seconds=1)),
+        delay_strategy=ExponentialBackoffDelayStrategy(),
         stop_strategy=MaxRetriesStopStrategy(max_retries))
 
-    with GarminClient(username, password) as client:
+    try:
+        client = GarminClient(username, password, auth_token_dir)
+        client.connect()
+
         # get all activity ids and timestamps from Garmin account
         log.info("scanning activities for %s ...", username)
         activities = set(retryer.call(client.list_activities))
@@ -73,3 +94,5 @@ def incremental_backup(username: str,
                 log.error("failed with exception: %s", e)
                 if not ignore_errors:
                     raise
+    finally:
+        client.disconnect()

--- a/garminexport/retryer.py
+++ b/garminexport/retryer.py
@@ -8,7 +8,7 @@ log = logging.getLogger(__name__)
 
 
 class GaveUpError(Exception):
-    """Raised by a :class:`Retryer` that has exceeded its maximum number of retries."""
+    """Raised by a Retryer that has exceeded its maximum number of retries."""
     pass
 
 
@@ -18,29 +18,27 @@ class DelayStrategy(object):
     __metaclass__ = abc.ABCMeta
 
     @abc.abstractmethod
-    def next_delay(self, attempts):
+    def next_delay(self, attempts: int) -> timedelta:
         """Returns the time to wait before the next attempt.
 
-        :param attempts: The total number of (failed) attempts performed thus far.
-        :type attempts: int
-
+        :param attempts: The total number of (failed) attempts performed thus
+          far.
         :return: The delay before the next attempt.
-        :rtype: `timedelta`
         """
         pass
 
 
 class FixedDelayStrategy(DelayStrategy):
-    """A retry :class:`DelayStrategy` that produces a fixed delay between attempts."""
+    """A retry :class:`DelayStrategy` that produces a fixed delay between
+    attempts."""
 
-    def __init__(self, delay):
+    def __init__(self, delay: timedelta):
         """
         :param delay: Attempt delay.
-        :type delay: `timedelta`
         """
         self.delay = delay
 
-    def next_delay(self, attempts):
+    def next_delay(self, attempts: int) -> timedelta:
         return self.delay
 
 
@@ -51,14 +49,14 @@ class ExponentialBackoffDelayStrategy(DelayStrategy):
     `<initial-delay> * 2**1`, `<initial-delay> * 2**2`, and so on ...
     """
 
-    def __init__(self, initial_delay):
+    def __init__(self, initial_delay: timedelta = timedelta(seconds=1)):
         """
         :param initial_delay: Initial delay.
         :type initial_delay: `timedelta`
         """
         self.initial_delay = initial_delay
 
-    def next_delay(self, attempts):
+    def next_delay(self, attempts: int) -> timedelta:
         if attempts <= 0:
             return timedelta(seconds=0)
         delay_seconds = self.initial_delay.total_seconds() * 2 ** (attempts - 1)
@@ -66,7 +64,7 @@ class ExponentialBackoffDelayStrategy(DelayStrategy):
 
 
 class NoDelayStrategy(FixedDelayStrategy):
-    """A retry :class:`DelayStrategy` that doesn't introduce any delay between attempts."""
+    """A retry DelayStrategy that doesn't introduce delay between attempts."""
 
     def __init__(self):
         super(NoDelayStrategy, self).__init__(timedelta(seconds=0))
@@ -74,13 +72,15 @@ class NoDelayStrategy(FixedDelayStrategy):
 
 class ErrorStrategy(object):
     """Used by a :class:`Retryer` to determine which errors are to be
-    suppressed and which errors are to be re-raised and thereby end the (re)trying."""
+    suppressed and which errors are to be re-raised and thereby end the
+    (re)trying. """
     __metaclass__ = abc.ABCMeta
 
     @abc.abstractmethod
-    def should_suppress(self, error):
+    def should_suppress(self, error) -> bool:
         """Called after an attempt that raised an exception to determine if
-        that error should be suppressed (continue retrying) or be re-raised (and end the retrying).
+        that error should be suppressed (continue retrying) or be re-raised
+        (and end the retrying).
 
         :param error: Error that was raised from an attempt.
         """
@@ -100,16 +100,12 @@ class StopStrategy(object):
     __metaclass__ = abc.ABCMeta
 
     @abc.abstractmethod
-    def should_continue(self, attempts, elapsed_time):
+    def should_continue(self, attempts: int, elapsed_time: timedelta) -> bool:
         """Called after a failed attempt to determine if we should keep trying.
 
         :param attempts: Total number of (failed) attempts thus far.
-        :type attempts: int
         :param elapsed_time: Total elapsed time since first attempt.
-        :type elapsed_time: timedelta
-
         :return: `True` if the `Retryer` should keep trying, `False` otherwise.
-        :rtype: bool
         """
         pass
 
@@ -117,17 +113,17 @@ class StopStrategy(object):
 class NeverStopStrategy(StopStrategy):
     """A :class:`StopStrategy` that never gives up."""
 
-    def should_continue(self, attempts, elapsed_time):
+    def should_continue(self, attempts: int, elapsed_time: timedelta):
         return True
 
 
 class MaxRetriesStopStrategy(StopStrategy):
-    """A :class:`StopStrategy` that gives up after a certain number of retries."""
+    """A StopStrategy that gives up after a certain number of retries."""
 
-    def __init__(self, max_retries):
+    def __init__(self, max_retries: int):
         self.max_retries = max_retries
 
-    def should_continue(self, attempts, elapsed_time):
+    def should_continue(self, attempts: int, elapsed_time: timedelta) -> bool:
         return attempts <= self.max_retries
 
 
@@ -189,7 +185,10 @@ class Retryer(object):
         :param args: Any positional arguments to call `function` with.
         :param kw: Any keyword arguments to call `function` with.
         """
-        name = function.__name__
+        argstr = ', '.join([str(a) for a in args])
+        kwstr = ', '.join(['{}:{}'.format(str(k), str(v)) for k, v in kw.items()])
+        kwstr = f', kw: {kwstr}' if kwstr else ''
+        name = '{}({}{})'.format(function.__name__, argstr, kwstr)
         start = datetime.now()
         attempts = 0
         while True:
@@ -199,17 +198,20 @@ class Retryer(object):
                 returnval = function(*args, **kw)
                 if self.returnval_predicate(returnval):
                     # return value satisfies predicate, we're done!
-                    log.debug('{%s}: success: "%s"', name, returnval)
+                    log.debug('{%s}: success', name)
                     return returnval
                 log.debug('{%s}: failed: return value: %s', name, returnval)
             except Exception as e:
-                if self.error_strategy is None or not self.error_strategy.should_suppress(e):
+                if (self.error_strategy is None) or \
+                   (not self.error_strategy.should_suppress(e)):
                     raise e
                 log.debug('{%s}: failed: error: %s', name, e)
             elapsed_time = datetime.now() - start
             # should we make another attempt?
             if not self.stop_strategy.should_continue(attempts, elapsed_time):
-                raise GaveUpError('{{}}: gave up after {} failed attempt(s)'.format(name, attempts))
+                raise GaveUpError('{}: gave up after {} failed attempt(s)'.
+                                  format(name, attempts))
             delay = self.delay_strategy.next_delay(attempts)
-            log.info('{%s}: waiting %d seconds for next attempt', name, delay.total_seconds())
+            log.info('{%s}: waiting %d seconds for next attempt',
+                     name, delay.total_seconds())
             time.sleep(delay.total_seconds())

--- a/garminexport/token_store.py
+++ b/garminexport/token_store.py
@@ -1,0 +1,116 @@
+import json
+import logging
+import os
+import os.path
+import time
+from typing import TypeAlias
+
+log = logging.getLogger(__name__)
+
+JwtFgpCookie: TypeAlias = str
+"""A JWT_FGP cookie value like 'e3794fe6-6613-4fde-9a3f-2c90e6912702'."""
+
+
+class OAuthToken(object):
+    """An OAuth1 token.
+      {
+         "access_token": "<about 1500 characters of base64>",
+         "token_type": "bearer",
+         "refresh_token": "<about 150 characters of base64>",
+         "expires_in": 3599,
+         "scope": "..",
+         "jti": "81458bbb-c4d9-4fdc-b08c-ac0327f82db9",
+         "refresh_token_expires_in": 7199
+       }
+    """
+
+    @staticmethod
+    def load(path: str) -> 'OAuthToken':
+        """Loads an oauth token from a json file."""
+        # Note: we make an assumption that the file was created when the token
+        # was acquired and therefore represents its age.
+        with open(path) as f:
+            age_s = time.time() - os.stat(path).st_mtime
+            return OAuthToken(json.load(f), age_s)
+
+    def __init__(self, token: dict, age_s: float):
+        self.fields = token
+        self.age_s = age_s
+        # OAuth token sanity check.
+        self._require_field(token, 'access_token')
+        self._require_field(token, 'token_type')
+        self._require_field(token, 'expires_in')
+        self._require_field(token, 'refresh_token')
+        self._require_field(token, 'refresh_token_expires_in')
+
+    def token_type(self) -> str:
+        """Returns the token type. For example 'Bearer'."""
+        return self.fields['token_type']
+
+    def access_token(self) -> str:
+        """Access token to be used as 'Authorization: Bearer <access_token>'
+        header to authenticate to the service."""
+        return self.fields['access_token']
+
+    def refresh_token(self) -> str:
+        """Refresh token used to request a new access token when it is has
+        expired or is near expiry."""
+        return self.fields['refresh_token']
+
+    def is_refresh_token_expired(self) -> bool:
+        """Indicates if the refresh_token has expired. If it has expired a new
+        OAuthToken needs to be acquired altogether."""
+        return self.time_to_refresh_token_expiry() <= 0
+
+    def _require_field(self, token: dict, field: str):
+        if field not in token:
+            raise ValueError(f'oauth token must have "{field}" field')
+
+    def time_to_expiry(self) -> float:
+        """Time in seconds until access_token expires."""
+        return max(0.0, self.fields['expires_in'] - self.age_s)
+
+    def time_to_refresh_token_expiry(self) -> float:
+        """Time in seconds until refresh_token expires."""
+        return max(0.0, self.fields['refresh_token_expires_in'] - self.age_s)
+
+
+class TokenStore(object):
+    """Manages (loads and stores) OAuth token and cookies needed to
+    authenticate with GarminConnect."""
+
+    def __init__(self, folder: str):
+        self.folder = folder
+        self.oauth_token_file = os.path.join(folder, 'oauth_token.json')
+        self.jwt_fgp_cookie_file = os.path.join(folder, 'jwt_fgp.cookie')
+        os.makedirs(self.folder, mode=0o700, exist_ok=True)
+
+    def has_fresh_tokens(self) -> bool:
+        """Returns True if the token store has a fresh OAuthToken (whose
+        refresh_token has not expired) and a JWT_FGP cookie, otherwise False.
+        """
+        # Both OAuth token and cookie are needed for authentication.
+        has_oauth_token = os.path.isfile(self.oauth_token_file)
+        has_jwt_fgp_cookie = os.path.isfile(self.jwt_fgp_cookie_file)
+        if (not has_oauth_token) or (not has_jwt_fgp_cookie):
+            return False
+        return not self.get_oauth_token().is_refresh_token_expired()
+
+    def set_oauth_token(self, token: OAuthToken):
+        """Stores a new OAuthToken in the store."""
+        with open(self.oauth_token_file, 'w') as f:
+            json.dump(token.fields, f, indent=2)
+
+    def get_oauth_token(self) -> OAuthToken:
+        """Loads the OAuthToken from the store."""
+        return OAuthToken.load(self.oauth_token_file)
+
+    def get_jwt_fgp_cookie(self) -> JwtFgpCookie:
+        """Loads the JWT_FGP cookie from the store."""
+        with open(self.jwt_fgp_cookie_file) as f:
+            return f.read().strip()
+
+    def set_jwt_fgp_cookie(self, value: JwtFgpCookie):
+        """Stores a new JWT_FGP cookie in the store."""
+        with open(self.jwt_fgp_cookie_file, 'w') as f:
+            f.write(value)

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,8 +24,6 @@ classifiers =
     Natural Language :: English
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
@@ -42,11 +40,6 @@ install_requires =
     python-dateutil~=2.4
 
 [options.extras_require]
-# Note: needed to impersonate web browsers. Garmin Connect uses Cloudflare's bot
-# protection which looks at TLS fingerprints to determine if the caller is a
-# script (like curl) or a web browser. curl_cffi uses a patched libcurl to
-# produce identical TLS fingerprints as real web browsers.
-impersonate_browser = curl_cffi==0.5.9
 test = pytest~=7.3; pytest-cov~=4.0
 
 [options.entry_points]


### PR DESCRIPTION
This PR changes the authentication flow to use new endpoints (notably `https://sso.garmin.com/sso/signin` over `https://sso.garmin.com/portal/api/login`).

It also reuses OAuth token and `JWT_FGP` cookie acquired from logins by storing them on disk (`~/.garminexport/`) to avoid being rate-limited by CloudFlare.

This new flow appears to be working well without the need for `cloudscraper` and `curl_cffi`.

Try it out:
```bash
$ git fetch
$ git checkout --track origin/change-auth-flow
# remove any prior virtual environment
$ rm -rf .venv 
$ make dev-init
$ source ~/.venv/bin/activate
$ garmin-backup  --log-level=INFO --password=<password> <username>
```