### PR TITLE
use android app auth flow (via garth)

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v3

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ clean:
 	rm -rf build dist garminexport.egg-info
 
 test:
-	pytest --cov=garminexport
+	pytest --cov=garminexport .
 
 ci-test:
 	pytest tests --junitxml=report.xml

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ As a user you only need to supply username and password to `garminexport` (you
 will also be prompted for an MFA code if your account has multi-factor
 authentication enabled). This information is handed over to the
 [garth](https://github.com/matin/garth) library which executes the same
-authentication flow of the Garmin Connect Android app to exchange your user
+authentication flow as the Garmin Connect Android app to exchange your user
 credentials for an [OAuth2](https://oauth.net/2/) token which is used to sign
 subsequent API requests.
 

--- a/README.md
+++ b/README.md
@@ -33,19 +33,17 @@ activities.
 
 ## Authentication
 
-Logging in with the user-supplied username and password gives `garminexport` two
-important pieces of data needed to authenticate further client requests:
+As a user you only need to supply username and password to `garminexport` (you
+will also be prompted for a MFA code if your account has multi-factor
+authentication enabled). This information is handed over to the
+[garth](https://github.com/matin/garth) library which executes the same
+authentication flow of the Garmin Connect Android app to exchange your user
+credentials for an [OAuth2](https://oauth.net/2/) token which is used to sign
+subsequent API requests.
 
-- An OAuth bearer token.
-- A `JWT_FGP` cookie.
-
-These are both stored under `~/.garmexport` (or the folder given by
-`--auth-token-dir`) and will be reused as long as the OAuth token has not
-expired. Only if the OAuth token has expired (normally after two hours) will a
-new login be initiated. Doing too many logins in a short period of time risks
-seeing your IP address being temporarily blocked by CloudFlare (normally
-indicated by a `429 (Too Many Requests)` response). The reuse of authentication
-tokens should make this a non-issue though.
+The oauth2 token is stored under `~/.garminexport` (or the folder given by
+`--auth-token-dir`) and will be reused as long as the token has not expired.
+Only if the OAuth token has expired will a new login be initiated.
 
 ## As a command-line tool (garmin-backup)
 
@@ -138,11 +136,13 @@ install_requires=[
 To start working on the code, create a virtual environment (an isolated
 development environment) and install the required dependencies like so:
 
-    # create virtualenv and populate it with library dependencies
-    make dev-init
+```bash
+# create virtualenv and populate it with library dependencies
+make dev-init
 
-    # activate virtualenv
-    source .venv/bin/activate
+# activate virtualenv
+source .venv/bin/activate
 
-    # test
-    make test
+# test
+make test
+```

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ activities.
 ## Authentication
 
 As a user you only need to supply username and password to `garminexport` (you
-will also be prompted for a MFA code if your account has multi-factor
+will also be prompted for an MFA code if your account has multi-factor
 authentication enabled). This information is handed over to the
 [garth](https://github.com/matin/garth) library which executes the same
 authentication flow of the Garmin Connect Android app to exchange your user

--- a/garminexport/authenticator.py
+++ b/garminexport/authenticator.py
@@ -1,60 +1,15 @@
 from collections.abc import Callable
+import garth
 import logging
 from functools import wraps
-import re
 import requests
 import requests.sessions
 from requests.sessions import Session
-from typing import TypeAlias
 
-from garminexport.token_store import JwtFgpCookie
-from garminexport.token_store import OAuthToken
-from garminexport.token_store import TokenStore
+from garminexport.token_store import TokenStore, time_to_expiry
+from garth.auth_tokens import OAuth1Token, OAuth2Token
 
 log = logging.getLogger(__name__)
-
-CASTicket: TypeAlias = str
-"""A CAS service ticket like "ST-01055566-3753GCopsoOm6yWrrXro-cas"."""
-
-SSO_EMBED_URL = "https://sso.garmin.com/sso/embed"
-"""Garmin Connect's single-signon embed URL."""
-SSO_SIGNIN_URL = "https://sso.garmin.com/sso/signin"
-"""The Garmin Connect single-signon signin URL. This is where the login form
-gets POSTed to get a CASTicket."""
-OAUTH_EXCHANGE_URL = 'https://connect.garmin.com/modern/di-oauth/exchange'
-"""URL to be called once a CAS ticket has been validated to exchange it for an
-OAuth token."""
-
-AUTH_TOKEN_REFRESH_URL = \
-    "https://connect.garmin.com/services/auth/token/refresh"
-"""Expects a POST with input JSON body like {"refresh_token": "eyJyZ..Q=="}.
-On success it returns 201 (Created) with an oauth token like below and sets a
-JWT_FGP cookie.
-{
-  "access_token": "<about 1500 characters of base64>",
-  "token_type": "bearer",
-  "refresh_token": "<about 150 characters of base64>",
-  "expires_in": 3599,
-  "scope": "..",
-  "jti": "81458bbb-c4d9-4fdc-b08c-ac0327f82db9",
-  "refresh_token_expires_in": 7199
-}
-"""
-
-ENTER_MFA_CODE_URL = "https://sso.garmin.com/sso/verifyMFA/loginEnterMfaCode"
-"""For users with multi-factor authentication enabled, this is the URL where
-the MFA code (sent by Garmin to the user) should be verified."""
-
-SIGNIN_PARAMS = {
-    'id':                              'gauth-widget',
-    'embedWidget':                     'true',
-    'clientId':                        'GarminConnect',
-    'gauthHost':                       SSO_EMBED_URL,
-    'service':                         SSO_EMBED_URL,
-    'source':                          SSO_EMBED_URL,
-    'redirectAfterAccountLoginUrl':    SSO_EMBED_URL,
-    'redirectAfterAccountCreationUrl': SSO_EMBED_URL}
-"""Query parameters to use for login atttempts against SSO_SIGNIN_URL."""
 
 
 def mfa_code_prompt() -> str:
@@ -92,9 +47,6 @@ class Authenticator(object):
     """Authenticator is intended to be configured for a GarminClient to prepare
     an authenticated session prior to making method calls annotated with the
     `@ensure_authenticated` decorator.
-
-    That will ensure a session is used with with proper headers (notably
-    `Authorization`, `Di-Backend`, and `NK`) and cookies (notably `JWT_FGP`).
     """
 
     def __init__(self, token_store: TokenStore, username: str, password: str,
@@ -103,189 +55,59 @@ class Authenticator(object):
         self.username = username
         self.password = password
         self.mfa_code_prompt = mfa_code_prompt
+        self.auth_client = garth.Client()
 
     def ensure_authenticated_session(self) -> Session:
-        """Returns a Session with authentication headers and cookies."""
-        oauth_tok, jwt_cookie = self._ensure_tokens()
+        """Returns a Session prepared with authentication headers."""
+        oauth2_token = self._ensure_token()
         # If the token is close to expiry we need to refresh it.
-        oauth_tok = self._ensure_fresh(oauth_tok, jwt_cookie)
+        oauth2_token = self._ensure_fresh(oauth2_token)
 
-        # Prepare an authenticated session with headers and cookies.
+        # TODO: could also get session directly from garth?
+
+        # Prepare an authenticated session with headers.
         authenticated_session = requests.Session()
         authenticated_session.headers.update({
             'Authorization': '{} {}'.format(
-                oauth_tok.token_type(), oauth_tok.access_token()),
+                oauth2_token.token_type, oauth2_token.access_token),
             'Di-Backend': 'connectapi.garmin.com',
             'NK': 'NT'})
-        authenticated_session.cookies.set(
-            'JWT_FGP', self.token_store.get_jwt_fgp_cookie())
         return authenticated_session
 
-    def _ensure_tokens(self) -> (OAuthToken, JwtFgpCookie):
-        if self.token_store.has_fresh_tokens():
-            log.debug("reusing existing oauth token found in token store ...")
-            return self.token_store.get_oauth_token(), self.token_store.get_jwt_fgp_cookie()
+    def _ensure_token(self) -> OAuth2Token:
+        if self.token_store.has_refreshable_token():
+            log.debug("has refreshable oauth2 token ...")
+            return self.token_store.get_oauth2_token()
 
-        log.debug("no fresh oauth token found, acquiring new ...")
-        oauth_token, jwt_fgp_cookie = self._acquire_tokens()
-        # Save in token_store
-        log.debug("saving acquired oauth token in token store ...")
-        self.token_store.set_oauth_token(oauth_token)
-        self.token_store.set_jwt_fgp_cookie(jwt_fgp_cookie)
-        return oauth_token, jwt_fgp_cookie
+        log.debug("no refreshable oauth2 token found, acquiring new ...")
+        oauth1_token, oauth2_token = self._acquire_tokens()
+        log.debug("saving acquired token in token store ...")
+        self._save_tokens(oauth1_token, oauth2_token)
+        return oauth2_token
 
-    def _ensure_fresh(self, token: OAuthToken, jwt_cookie: JwtFgpCookie) \
-            -> OAuthToken:
-        if token.time_to_expiry() > 60:
-            log.debug("access_token still fresh (expires in %.1f seconds)",
-                      token.time_to_expiry())
+    def _ensure_fresh(self, token: OAuth2Token) -> OAuth2Token:
+        if time_to_expiry(token) > 60:
+            log.debug("access_token still fresh (expires in %.1fs)",
+                      time_to_expiry(token))
             return token
         # Refresh auth token and save in token store.
-        log.debug("refreshing oauth token (expires in %.1f seconds) ...",
-                  token.time_to_expiry())
-        headers = {
-            'Authorization': f'{token.token_type()} {token.access_token()}',
-            'Di-Backend': 'connectapi.garmin.com',
-            'NK': 'NT'}
-        resp = requests.post(AUTH_TOKEN_REFRESH_URL,
-                             cookies={'JWT_FGP': jwt_cookie}, headers=headers,
-                             json={'refresh_token': token.refresh_token()})
-        if resp.status_code != 201:
-            raise ValueError(f'refresh oauth token: {resp.status_code}: '
-                             f'{resp.text}')
-        new_token = OAuthToken(resp.json(), age_s=0)
-        jwt_fgp_cookie = resp.cookies['JWT_FGP']
-        # Save in token store.
+        log.debug("refreshing oauth2 token (expires in %.1fs) ...",
+                  time_to_expiry(token))
+        self.auth_client.refresh_oauth2()
         log.debug("saving refreshed oauth token ...")
-        self.token_store.set_oauth_token(new_token)
-        self.token_store.set_jwt_fgp_cookie(jwt_fgp_cookie)
-        return new_token
+        self._save_tokens(
+            self.auth_client.oauth1_token, self.auth_client.oauth2_token)
+        return self.auth_client.oauth2_token
 
-    def _acquire_tokens(self) -> (OAuthToken, JwtFgpCookie):
-        log.debug("acquiring authentication tokens ...")
-        auth_client = requests.Session()
-        cas_ticket = self._login(auth_client, self.username, self.password)
-        log.debug("got CAS ticket: %s", cas_ticket)
-        self._validate_cas_ticket(auth_client, cas_ticket)
-        return self._fetch_oauth_token(auth_client)
+    def _acquire_tokens(self) -> (OAuth1Token, OAuth2Token):
+        """Perform full login to acquire both OAuth1Token and OAuth2Token."""
+        log.debug("acquiring authentication token ...")
+        oauth1_token, oauth2_token = self.auth_client.login(
+            self.username, self.password, prompt_mfa=self.mfa_code_prompt)
+        return oauth1_token, oauth2_token
 
-    def _login(self, auth_client: Session, username, password: str) \
-            -> CASTicket:
-        log.debug("logging in ...")
-        # Set cookies.
-        log.debug("log in: calling sso/embed to set cookies ...")
-        resp = auth_client.get(SSO_EMBED_URL, params={
-            'embedWidget': 'true',
-            'gauthHost': 'https://sso.garmin.com/sso',
-            'id': 'gauth-widget'})
-        require_status(resp, 200)
-        # Get CSRF token.
-        csrf_token = self._get_csrf_token(auth_client)
-        # Submit login form
-        ticket = self._get_login_auth_ticket(auth_client, csrf_token)
-        return ticket
-
-    def _validate_cas_ticket(self, auth_client: Session, ticket: CASTicket):
-        """Validates a CAS authentication ticket
-        ("ST-01055566-3753GCopsoOm6yWrrXro-cas") granted from a prior login
-        form submission."""
-        log.debug("validating CAS ticket %s ...", ticket)
-        auth_client.get('https://connect.garmin.com/modern/', headers={},
-                        params={'ticket': ticket})
-
-    def _fetch_oauth_token(self, auth_client: Session) -> \
-            (OAuthToken, JwtFgpCookie):
-        log.debug("exchanging CAS ticket for OAuth token ...")
-        headers = {
-            'authority': 'connect.garmin.com',
-            'origin': 'https://connect.garmin.com',
-            'referer': 'https://connect.garmin.com/modern/'}
-        resp = auth_client.post(OAUTH_EXCHANGE_URL, headers=headers)
-        require_status(resp, 200)
-        token = OAuthToken(resp.json(), 0)
-        return token, auth_client.cookies['JWT_FGP']
-
-    def _get_csrf_token(self, auth_client: Session) -> str:
-        resp = auth_client.get(SSO_SIGNIN_URL, params=SIGNIN_PARAMS)
-        require_status(resp, 200)
-        return find_page_csrf_token(resp.text)
-
-    def _get_login_auth_ticket(self, auth_client: Session, csrf_token: str) \
-            -> CASTicket:
-        form_data = dict(username=self.username, password=self.password,
-                         embed="true", _csrf=csrf_token)
-        form_headers = {
-            'Content-Type': 'application/x-www-form-urlencoded',
-            'Referer': SSO_SIGNIN_URL}
-        log.debug("using CSRF token for signin page: '%s'", csrf_token)
-        resp = auth_client.post(SSO_SIGNIN_URL, headers=form_headers,
-                                params=SIGNIN_PARAMS, data=form_data)
-        if resp.status_code == 429:
-            # CloudFlare blocked us. Retry in one hour.
-            raise ValueError(
-                'Authentication attempt gave 429 (Too Many Requests). '
-                'You are being rate limited. Please back off.')
-        title = get_page_title(resp.text)
-        log.debug("got login page response:\n%s", resp.text)
-        # Note: if the account has multi-factor authentication enabled an MFA
-        # code will be sent to the user (as SMS or email, depending on user
-        # settings).
-        if title == "Enter MFA code for login":
-            csrf_token = find_page_csrf_token(resp.text)
-            mfa_code = self.mfa_code_prompt()
-            log.debug("using CSRF token for mfa verification page: '%s'", csrf_token)
-            log.debug("using MFA code: '%s'", csrf_token)
-            resp = self._verify_mfa_code(auth_client, csrf_token, mfa_code)
-            title = get_page_title(resp.text)
-        if title != "Success":
-            raise ValueError(f'auth attempt failed with {resp.status_code}: '
-                             f'{resp.text}')
-        m = re.search(r'ticket=(ST-[^"]+)', resp.text)
-        if not m:
-            raise ValueError(f'no ticket found in {SSO_SIGNIN_URL} response')
-        ticket = m.group(1)
-        return ticket
-
-    def _verify_mfa_code(self, auth_client: Session, csrf_token: str,
-                         mfa_code: str) -> requests.Response:
-        form_data = {"mfa-code": mfa_code, "embed": "true",
-                     "_csrf": csrf_token, "fromPage": "setupEnterMfaCode"}
-        headers = {'referer': SSO_SIGNIN_URL}
-        resp = auth_client.post(ENTER_MFA_CODE_URL, params=SIGNIN_PARAMS,
-                                data=form_data, headers=headers)
-        log.debug("verify MFA response: %d:\n%s", resp.status_code, resp.text)
-        return resp
-
-
-def require_status(resp: requests.Response, want_code: int):
-    """Raises an error unless the response has a given HTTP status code."""
-    if resp.status_code != want_code:
-        raise ValueError(
-            f'{resp.request.method} {resp.request.url} '
-            f'gave {resp.status_code} (wanted {want_code}): {resp.text}')
-
-
-TITLE_RE = re.compile(r"<title>(.+?)</title>")
-"""Regular expression used to capture the page title when submitting a login
-form to SSO_SIGNIN_URL."""
-
-
-def get_page_title(html: str) -> str:
-    """Retrieve the title element from a HTML page."""
-    m = TITLE_RE.search(html)
-    if not m:
-        raise ValueError("couldn't find page title")
-    return m.group(1)
-
-
-CSRF_RE = re.compile(r'name="_csrf"\s+value="(?P<token>.+?)"')
-"""Regular expression used to capture the CSRF token from the SSO_SIGNIN_URL
-page."""
-
-
-def find_page_csrf_token(html: str) -> str:
-    m = CSRF_RE.search(html)
-    if not m:
-        raise ValueError('no CSRF token found in page')
-    csrf_token = m.group('token')
-    return csrf_token
+    def _save_tokens(self, oauth1_token: OAuth1Token,
+                     oauth2_token: OAuth2Token):
+        """Saves acquired oauth tokens to the TokenStore."""
+        self.token_store.set_oauth1_token(oauth1_token)
+        self.token_store.set_oauth2_token(oauth2_token)

--- a/garminexport/authenticator.py
+++ b/garminexport/authenticator.py
@@ -63,8 +63,6 @@ class Authenticator(object):
         # If the token is close to expiry we need to refresh it.
         oauth2_token = self._ensure_fresh(oauth2_token)
 
-        # TODO: could also get session directly from garth?
-
         # Prepare an authenticated session with headers.
         authenticated_session = requests.Session()
         authenticated_session.headers.update({

--- a/garminexport/cli/backup.py
+++ b/garminexport/cli/backup.py
@@ -75,7 +75,7 @@ def parse_args() -> argparse.Namespace:
 
 def main():
     args = parse_args()
-    logging.root.setLevel(LOG_LEVELS[args.log_level])
+    logging.root.setLevel(LOG_LEVELS[args.log_level.upper()])
 
     try:
         incremental_backup(username=args.username,

--- a/garminexport/cli/get_activity.py
+++ b/garminexport/cli/get_activity.py
@@ -11,9 +11,11 @@ from datetime import timedelta
 import dateutil.parser
 
 import garminexport.backup
+from garminexport.cli.backup import DEFAULT_AUTH_TOKEN_DIR
 from garminexport.garminclient import GarminClient
 from garminexport.logging_config import LOG_LEVELS
-from garminexport.retryer import Retryer, ExponentialBackoffDelayStrategy, MaxRetriesStopStrategy
+from garminexport.retryer import (Retryer, ExponentialBackoffDelayStrategy,
+                                  MaxRetriesStopStrategy)
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)-15s [%(levelname)s] %(message)s")
 log = logging.getLogger(__name__)
@@ -21,7 +23,7 @@ log = logging.getLogger(__name__)
 
 def main():
     parser = argparse.ArgumentParser(
-        description="Downloads one particular activity for a given Garmin Connect account.")
+        description="Downloads one particular activity.")
 
     # positional args
     parser.add_argument(
@@ -36,8 +38,12 @@ def main():
     parser.add_argument(
         "--password", type=str, help="Account password.")
     parser.add_argument(
+        "--auth-token-dir", metavar="DIR", type=str,
+        help=f"Folder where auth tokens saved. Default: {DEFAULT_AUTH_TOKEN_DIR}",
+        default=DEFAULT_AUTH_TOKEN_DIR)
+    parser.add_argument(
         "--destination", metavar="DIR", type=str,
-        help="Destination directory for downloaded activity. Default: ./activities/",
+        help="Destination folder for downloaded activity. Default: ./activities/",
         default=os.path.join(".", "activities"))
     parser.add_argument(
         "--log-level", metavar="LEVEL", type=str,
@@ -63,17 +69,21 @@ def main():
         if not args.password:
             args.password = getpass.getpass("Enter password: ")
 
-        with GarminClient(args.username, args.password) as client:
-            log.info("fetching activity %s ...", args.activity)
-            summary = client.get_activity_summary(args.activity)
-            # set up a retryer that will handle retries of failed activity downloads
-            retryer = Retryer(
-                delay_strategy=ExponentialBackoffDelayStrategy(initial_delay=timedelta(seconds=1)),
-                stop_strategy=MaxRetriesStopStrategy(5))
+        client = GarminClient(args.username, args.password, args.auth_token_dir)
+        client.connect()
 
-            start_time = dateutil.parser.parse(summary["summaryDTO"]["startTimeGMT"])
-            garminexport.backup.download(
-                client, (args.activity, start_time), retryer, args.destination, export_formats=[args.format])
+        log.info("fetching activity %s ...", args.activity)
+        summary = client.get_activity_summary(args.activity)
+        # set up a retryer that will handle retries of failed activity downloads
+        retryer = Retryer(
+            delay_strategy=ExponentialBackoffDelayStrategy(initial_delay=timedelta(seconds=1)),
+            stop_strategy=MaxRetriesStopStrategy(5))
+
+        start_time = dateutil.parser.parse(summary["summaryDTO"]["startTimeGMT"])
+        garminexport.backup.download(
+            client, (args.activity, start_time), retryer, args.destination, export_formats=[args.format])
     except Exception as e:
         log.error("failed with exception: %s", e)
         raise
+    finally:
+        client.disconnect()

--- a/garminexport/cli/upload_activity.py
+++ b/garminexport/cli/upload_activity.py
@@ -7,6 +7,7 @@ import logging
 
 from garminexport.garminclient import GarminClient
 from garminexport.logging_config import LOG_LEVELS
+from garminexport.cli.backup import DEFAULT_AUTH_TOKEN_DIR
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)-15s [%(levelname)s] %(message)s")
 log = logging.getLogger(__name__)
@@ -26,6 +27,10 @@ def main():
     # optional args
     parser.add_argument(
         "--password", type=str, help="Account password.")
+    parser.add_argument(
+        "--auth-token-dir", metavar="DIR", type=str,
+        help=f"Folder where auth tokens saved. Default: {DEFAULT_AUTH_TOKEN_DIR}",
+        default=DEFAULT_AUTH_TOKEN_DIR)
     parser.add_argument(
         '-N', '--name', help="Activity name on Garmin Connect.")
     parser.add_argument(
@@ -53,17 +58,21 @@ def main():
         if not args.password:
             args.password = getpass.getpass("Enter password: ")
 
-        with GarminClient(args.username, args.password) as client:
-            for activity in args.activity:
-                log.info("uploading activity file %s ...", activity.name)
-                try:
-                    id = client.upload_activity(activity, name=args.name, description=args.description,
-                                                private=args.private, activity_type=args.type)
-                except Exception as e:
-                    log.error("upload failed: {!r}".format(e))
-                else:
-                    log.info("upload successful: https://connect.garmin.com/modern/activity/%s", id)
+        client = GarminClient(args.username, args.password, args.auth_token_dir)
+        client.connect()
+
+        for activity in args.activity:
+            log.info("uploading activity file %s ...", activity.name)
+            try:
+                id = client.upload_activity(activity, name=args.name, description=args.description,
+                                            private=args.private, activity_type=args.type)
+            except Exception as e:
+                log.error("upload failed: {!r}".format(e))
+            else:
+                log.info("upload successful: https://connect.garmin.com/modern/activity/%s", id)
 
     except Exception as e:
         log.error("failed with exception: %s", e)
         raise
+    finally:
+        client.disconnect()

--- a/garminexport/garminclient.py
+++ b/garminexport/garminclient.py
@@ -16,8 +16,7 @@ import sys
 import zipfile
 
 from garminexport.authenticator import (Authenticator,
-                                        ensure_authenticated,
-                                        require_status)
+                                        ensure_authenticated)
 from garminexport.retryer import (Retryer,
                                   ExponentialBackoffDelayStrategy,
                                   MaxRetriesStopStrategy)
@@ -26,7 +25,9 @@ from garminexport.token_store import TokenStore
 
 log = logging.getLogger(__name__)
 # reduce logging noise from requests library
+logging.getLogger("oauthlib").setLevel(logging.ERROR)
 logging.getLogger("requests").setLevel(logging.ERROR)
+logging.getLogger("requests-oauthlib").setLevel(logging.ERROR)
 
 
 class GarminClient(object):
@@ -121,7 +122,7 @@ class GarminClient(object):
         log.debug("fetching activities %d through %d ...",
                   start_index, start_index + max_limit - 1)
         response = self.session.get(
-            "https://connect.garmin.com/activitylist-service/activities/search/activities",
+            "https://connectapi.garmin.com/activitylist-service/activities/search/activities",
             params={"start": start_index, "limit": max_limit})
         if response.status_code != 200:
             raise Exception(
@@ -155,7 +156,7 @@ class GarminClient(object):
 
         """
         response = self.session.get(
-            "https://connect.garmin.com/activity-service/activity/{}".
+            "https://connectapi.garmin.com/activity-service/activity/{}".
             format(activity_id))
         require_status(response, 200)
         return json.loads(response.text)
@@ -169,9 +170,8 @@ class GarminClient(object):
         :param activity_id: Activity identifier.
         :returns: The activity details as a JSON dict.
         """
-        # mounted at xml or json depending on result encoding
         response = self.session.get(
-            "https://connect.garmin.com/activity-service/activity/{}/details".
+            "https://connectapi.garmin.com/activity-service/activity/{}/details".
             format(activity_id))
         require_status(response, 200)
         return json.loads(response.text)
@@ -188,12 +188,8 @@ class GarminClient(object):
           or ``None`` if the activity couldn't be exported to GPX.
         """
         response = self.session.get(
-            "https://connect.garmin.com/download-service/export/gpx/activity/{}"
+            "https://connectapi.garmin.com/download-service/export/gpx/activity/{}"
             .format(activity_id))
-        # An alternate URL that seems to produce the same results
-        # and is the one used when exporting through the Garmin
-        # Connect web page.
-        # response = self.session.get("https://connect.garmin.com/proxy/activity-service-1.1/gpx/activity/{}?full=true".format(activity_id))
 
         # A 404 (Not Found) or 204 (No Content) response are both indicators
         # of a gpx file not being available for the activity. It may, for
@@ -217,7 +213,7 @@ class GarminClient(object):
         """
 
         response = self.session.get(
-            "https://connect.garmin.com/download-service/export/tcx/activity/{}"
+            "https://connectapi.garmin.com/download-service/export/tcx/activity/{}"
             .format(activity_id))
         if response.status_code == 404:
             return None
@@ -235,7 +231,7 @@ class GarminClient(object):
           its contents, or :obj:`(None,None)` if no file is found.
         """
         response = self.session.get(
-            "https://connect.garmin.com/download-service/files/activity/{}"
+            "https://connectapi.garmin.com/download-service/files/activity/{}"
             .format(activity_id))
         # A 404 (Not Found) response is a clear indicator of a missing .fit
         # file. As of lately, the endpoint appears to have started to
@@ -285,7 +281,7 @@ class GarminClient(object):
         :returns: Garmin's internalId for the newly-created activity, or
           :obj:`None` if upload is still processing.
         """
-        response = self.session.get("https://connect.garmin.com/proxy/activity-service/activity/status/{}/{}?_={}".format(
+        response = self.session.get("https://connectapi.garmin.com/proxy/activity-service/activity/status/{}/{}?_={}".format(
             creation_date[:10], uuid.replace("-",""), int(datetime.now().timestamp() * 1000)), headers={"nk": "NT"})
         if response.status_code == 201 and response.headers["location"]:
             # location should be https://connectapi.garmin.com/activity-service/activity/ACTIVITY_ID
@@ -324,8 +320,8 @@ class GarminClient(object):
 
         # upload it
         files = dict(data=(fn, file))
-        response = self.session.post("https://connect.garmin.com/proxy/upload-service/upload/.{}".format(format),
-                                     files=files, headers={"nk": "NT"})
+        response = self.session.post("https://connectapi.garmin.com/proxy/upload-service/upload/.{}".format(format),
+                                     files=files, headers={"nk": "NT"}) # TODO redundant?
 
         # check response and get activity ID
         try:
@@ -377,10 +373,18 @@ class GarminClient(object):
             data['activityId'] = activity_id
             encoding_headers = {"Content-Type": "application/json; charset=UTF-8"}  # see Tapiriik
             response = self.session.put(
-                "https://connect.garmin.com/proxy/activity-service/activity/{}".format(activity_id),
+                "https://connectapi.garmin.com/proxy/activity-service/activity/{}".format(activity_id),
                 data=json.dumps(data), headers=encoding_headers)
             if response.status_code != 204:
                 raise Exception(u"failed to set metadata for activity {}: {}\n{}".format(
                     activity_id, response.status_code, response.text))
 
         return activity_id
+
+
+def require_status(resp: requests.Response, want_code: int):
+    """Raises an error unless the response has a given HTTP status code."""
+    if resp.status_code != want_code:
+        raise ValueError(
+            f'{resp.request.method} {resp.request.url} '
+            f'gave {resp.status_code} (wanted {want_code}): {resp.text}')

--- a/garminexport/garminclient.py
+++ b/garminexport/garminclient.py
@@ -269,29 +269,6 @@ class GarminClient(object):
         return orig_file if fmt == 'fit' else None
 
     @ensure_authenticated
-    def _poll_upload_completion(self, uuid: str, creation_date: str) -> int:
-        """Poll for completion of an upload. If Garmin connect returns
-        HTTP status 202 ("Accepted") after initial upload, then we must poll
-        until the upload has either succeeded or failed. Raises an
-        :class:`Exception` if the upload has failed.
-
-        :param uuid: uploadUuid returned on initial upload.
-        :param creation_date: creationDate returned from initial upload (e.g.
-          "2020-01-01 12:34:56.789 GMT")
-        :returns: Garmin's internalId for the newly-created activity, or
-          :obj:`None` if upload is still processing.
-        """
-        response = self.session.get("https://connectapi.garmin.com/proxy/activity-service/activity/status/{}/{}?_={}".format(
-            creation_date[:10], uuid.replace("-",""), int(datetime.now().timestamp() * 1000)), headers={"nk": "NT"})
-        if response.status_code == 201 and response.headers["location"]:
-            # location should be https://connectapi.garmin.com/activity-service/activity/ACTIVITY_ID
-            return int(response.headers["location"].split("/")[-1])
-        elif response.status_code == 202:
-            return None # still processing
-        else:
-            response.raise_for_status()
-
-    @ensure_authenticated
     def upload_activity(self, file: str, format: str = None, name: str = None, \
                         description: str = None, activity_type: str = None, \
                         private: bool = None) -> int:
@@ -320,44 +297,21 @@ class GarminClient(object):
 
         # upload it
         files = dict(data=(fn, file))
-        response = self.session.post("https://connectapi.garmin.com/proxy/upload-service/upload/.{}".format(format),
-                                     files=files, headers={"nk": "NT"}) # TODO redundant?
+        response = self.session.post(
+            f'https://connectapi.garmin.com/upload-service/upload/{format}',
+            files=files)
 
-        # check response and get activity ID
-        try:
-            j = response.json()["detailedImportResult"]
-        except (json.JSONDecodeError, KeyError):
-            raise Exception(u"failed to upload {} for activity: {}\n{}".format(
-                format, response.status_code, response.text))
+        log.debug("got upload response:\n%s", json.dumps(response.json(), indent=2))
 
-        # single activity, immediate success
-        if len(j["successes"]) == 1 and len(j["failures"]) == 0:
-            activity_id = j["successes"][0]["internalId"]
-
-        # duplicate of existing activity
-        elif len(j["failures"]) == 1 and len(j["successes"]) == 0 and response.status_code == 409:
-            log.info(u"duplicate activity uploaded, continuing")
-            activity_id = j["failures"][0]["internalId"]
-
-        # need to poll until success/failure
-        elif len(j["failures"]) == 0 and len(j["successes"]) == 0 and response.status_code == 202:
-            retryer = Retryer(
-                returnval_predicate=bool,
-                delay_strategy=ExponentialBackoffDelayStrategy(initial_delay=timedelta(seconds=1)),
-                stop_strategy=MaxRetriesStopStrategy(6), # wait for up to 64 seconds (2**6)
-                error_strategy=None
-            )
-            activity_id = retryer.call(self._poll_upload_completion, j["uploadUuid"]["uuid"], j["creationDate"])
-
-        # don't know how to handle multiple activities
-        elif len(j["successes"]) > 1:
-            raise Exception(u"uploading {} resulted in multiple activities ({})".format(
-                format, len(j["successes"])))
-
-        # all other errors
-        else:
-            raise Exception(u"failed to upload {} for activity: {}\n{}".format(
-                format, response.status_code, j["failures"]))
+        require_status(response, 202)
+        poll_url = response.headers["Location"]
+        log.debug("polling upload completion at %s ...", poll_url)
+        retryer = Retryer(
+            returnval_predicate=bool,
+            delay_strategy=ExponentialBackoffDelayStrategy(),
+            stop_strategy=MaxRetriesStopStrategy(6),
+            error_strategy=None)
+        activity_id = retryer.call(self._poll_upload_completion, poll_url)
 
         # add optional fields
         data = {}
@@ -371,15 +325,37 @@ class GarminClient(object):
             data['privacy'] = {"typeKey": "private"}
         if data:
             data['activityId'] = activity_id
-            encoding_headers = {"Content-Type": "application/json; charset=UTF-8"}  # see Tapiriik
+            encoding_headers = {"Content-Type": "application/json; charset=UTF-8"}
             response = self.session.put(
-                "https://connectapi.garmin.com/proxy/activity-service/activity/{}".format(activity_id),
+                "https://connectapi.garmin.com/activity-service/activity/{}".format(activity_id),
                 data=json.dumps(data), headers=encoding_headers)
             if response.status_code != 204:
                 raise Exception(u"failed to set metadata for activity {}: {}\n{}".format(
                     activity_id, response.status_code, response.text))
 
         return activity_id
+
+    @ensure_authenticated
+    def _poll_upload_completion(self, poll_url: str) -> int:
+        """Poll for completion of an upload. If Garmin connect returns
+        HTTP status 202 ("Accepted") after initial upload, then we must poll
+        until the upload has either succeeded or failed. Raises an
+        :class:`Exception` if the upload has failed.
+
+        :param poll_url: The URL where upload completion can be polled.
+        :returns: Garmin's internalId for the newly-created activity, or
+          :obj:`None` if upload is still processing.
+        """
+        response = self.session.get(poll_url)
+        if response.status_code == 201 and response.headers["location"]:
+            # Location header should be of form:
+            # https://connectapi.garmin.com/activity-service/activity/<id>
+            return int(os.path.basename(response.headers["location"]))
+        elif response.status_code == 202:
+            # Still processing.
+            return None
+        else:
+            response.raise_for_status()
 
 
 def require_status(resp: requests.Response, want_code: int):

--- a/garminexport/token_store.py
+++ b/garminexport/token_store.py
@@ -1,116 +1,58 @@
-import json
+from datetime import datetime
+import garth
+from garth.auth_tokens import OAuth1Token, OAuth2Token
 import logging
 import os
 import os.path
-import time
-from typing import TypeAlias
 
 log = logging.getLogger(__name__)
 
-JwtFgpCookie: TypeAlias = str
-"""A JWT_FGP cookie value like 'e3794fe6-6613-4fde-9a3f-2c90e6912702'."""
-
-
-class OAuthToken(object):
-    """An OAuth1 token.
-      {
-         "access_token": "<about 1500 characters of base64>",
-         "token_type": "bearer",
-         "refresh_token": "<about 150 characters of base64>",
-         "expires_in": 3599,
-         "scope": "..",
-         "jti": "81458bbb-c4d9-4fdc-b08c-ac0327f82db9",
-         "refresh_token_expires_in": 7199
-       }
-    """
-
-    @staticmethod
-    def load(path: str) -> 'OAuthToken':
-        """Loads an oauth token from a json file."""
-        # Note: we make an assumption that the file was created when the token
-        # was acquired and therefore represents its age.
-        with open(path) as f:
-            age_s = time.time() - os.stat(path).st_mtime
-            return OAuthToken(json.load(f), age_s)
-
-    def __init__(self, token: dict, age_s: float):
-        self.fields = token
-        self.age_s = age_s
-        # OAuth token sanity check.
-        self._require_field(token, 'access_token')
-        self._require_field(token, 'token_type')
-        self._require_field(token, 'expires_in')
-        self._require_field(token, 'refresh_token')
-        self._require_field(token, 'refresh_token_expires_in')
-
-    def token_type(self) -> str:
-        """Returns the token type. For example 'Bearer'."""
-        return self.fields['token_type']
-
-    def access_token(self) -> str:
-        """Access token to be used as 'Authorization: Bearer <access_token>'
-        header to authenticate to the service."""
-        return self.fields['access_token']
-
-    def refresh_token(self) -> str:
-        """Refresh token used to request a new access token when it is has
-        expired or is near expiry."""
-        return self.fields['refresh_token']
-
-    def is_refresh_token_expired(self) -> bool:
-        """Indicates if the refresh_token has expired. If it has expired a new
-        OAuthToken needs to be acquired altogether."""
-        return self.time_to_refresh_token_expiry() <= 0
-
-    def _require_field(self, token: dict, field: str):
-        if field not in token:
-            raise ValueError(f'oauth token must have "{field}" field')
-
-    def time_to_expiry(self) -> float:
-        """Time in seconds until access_token expires."""
-        return max(0.0, self.fields['expires_in'] - self.age_s)
-
-    def time_to_refresh_token_expiry(self) -> float:
-        """Time in seconds until refresh_token expires."""
-        return max(0.0, self.fields['refresh_token_expires_in'] - self.age_s)
-
 
 class TokenStore(object):
-    """Manages (loads and stores) OAuth token and cookies needed to
-    authenticate with GarminConnect."""
+    """Manages (loads and stores) OAuth tokens needed to authenticate with
+    GarminConnect.
+    """
 
     def __init__(self, folder: str):
         self.folder = folder
-        self.oauth_token_file = os.path.join(folder, 'oauth_token.json')
-        self.jwt_fgp_cookie_file = os.path.join(folder, 'jwt_fgp.cookie')
+        self.auth_client = garth.Client()
         os.makedirs(self.folder, mode=0o700, exist_ok=True)
 
-    def has_fresh_tokens(self) -> bool:
-        """Returns True if the token store has a fresh OAuthToken (whose
-        refresh_token has not expired) and a JWT_FGP cookie, otherwise False.
-        """
-        # Both OAuth token and cookie are needed for authentication.
-        has_oauth_token = os.path.isfile(self.oauth_token_file)
-        has_jwt_fgp_cookie = os.path.isfile(self.jwt_fgp_cookie_file)
-        if (not has_oauth_token) or (not has_jwt_fgp_cookie):
+    def has_refreshable_token(self) -> bool:
+        """Indicates if the token store has an OAuth2Token with a refresh_token
+        that has not expired."""
+        try:
+            # Try to load saved token.
+            oauth2_token = self.get_oauth2_token()
+        except Exception:
             return False
-        return not self.get_oauth_token().is_refresh_token_expired()
+        return not oauth2_token.refresh_expired
 
-    def set_oauth_token(self, token: OAuthToken):
-        """Stores a new OAuthToken in the store."""
-        with open(self.oauth_token_file, 'w') as f:
-            json.dump(token.fields, f, indent=2)
+    def get_oauth2_token(self) -> OAuth2Token:
+        if self.auth_client.oauth2_token is None:
+            self.auth_client.load(self.folder)
+        return self.auth_client.oauth2_token
 
-    def get_oauth_token(self) -> OAuthToken:
-        """Loads the OAuthToken from the store."""
-        return OAuthToken.load(self.oauth_token_file)
+    def set_oauth1_token(self, token: OAuth1Token):
+        """Stores a new OAuth1Token in the store."""
+        self.auth_client.oauth1_token = token
+        self.auth_client.dump(self.folder)
 
-    def get_jwt_fgp_cookie(self) -> JwtFgpCookie:
-        """Loads the JWT_FGP cookie from the store."""
-        with open(self.jwt_fgp_cookie_file) as f:
-            return f.read().strip()
+    def set_oauth2_token(self, token: OAuth2Token):
+        """Stores a new OAuth2Token in the store."""
+        self.auth_client.oauth2_token = token
+        self.auth_client.dump(self.folder)
 
-    def set_jwt_fgp_cookie(self, value: JwtFgpCookie):
-        """Stores a new JWT_FGP cookie in the store."""
-        with open(self.jwt_fgp_cookie_file, 'w') as f:
-            f.write(value)
+
+def time_to_expiry(token: OAuth2Token) -> float:
+    """Time in seconds until the OAuth2Token access_token expires."""
+    expire_time = datetime.fromtimestamp(token.expires_at)
+    expires_in = (expire_time - datetime.now()).total_seconds()
+    return max(0.0, expires_in)
+
+
+def time_to_refresh_expiry(token: OAuth2Token) -> float:
+    """Time in seconds until OAuth2Token refresh_token expires."""
+    expire_time = datetime.fromtimestamp(token.refresh_token_expires_at)
+    expires_in = (expire_time - datetime.now()).total_seconds()
+    return max(0.0, expires_in)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,20 +4,30 @@
 #
 #    pip-compile --extra=test --output-file=requirements-dev.txt
 #
-certifi==2025.8.3
+annotated-types==0.7.0
+    # via pydantic
+certifi==2025.11.12
     # via requests
-charset-normalizer==3.4.3
+charset-normalizer==3.4.4
     # via requests
-coverage[toml]==7.10.4
+coverage[toml]==7.13.0
     # via pytest-cov
-idna==3.10
+garth==0.5.19
+    # via garminexport (setup.py)
+idna==3.11
     # via requests
-iniconfig==2.1.0
+iniconfig==2.3.0
     # via pytest
+oauthlib==3.3.1
+    # via requests-oauthlib
 packaging==25.0
     # via pytest
 pluggy==1.6.0
     # via pytest
+pydantic==2.12.5
+    # via garth
+pydantic-core==2.41.5
+    # via pydantic
 pytest==7.4.4
     # via
     #   garminexport (setup.py)
@@ -26,9 +36,21 @@ pytest-cov==4.1.0
     # via garminexport (setup.py)
 python-dateutil==2.9.0.post0
     # via garminexport (setup.py)
-requests==2.32.4
-    # via garminexport (setup.py)
+requests==2.32.5
+    # via
+    #   garminexport (setup.py)
+    #   garth
+    #   requests-oauthlib
+requests-oauthlib==2.0.0
+    # via garth
 six==1.17.0
     # via python-dateutil
-urllib3==2.5.0
+typing-extensions==4.15.0
+    # via
+    #   pydantic
+    #   pydantic-core
+    #   typing-inspection
+typing-inspection==0.4.2
+    # via pydantic
+urllib3==2.6.2
     # via requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,17 +4,39 @@
 #
 #    pip-compile --output-file=requirements.txt
 #
-certifi==2025.8.3
+annotated-types==0.7.0
+    # via pydantic
+certifi==2025.11.12
     # via requests
-charset-normalizer==3.4.3
+charset-normalizer==3.4.4
     # via requests
-idna==3.10
+garth==0.5.19
+    # via garminexport (setup.py)
+idna==3.11
     # via requests
+oauthlib==3.3.1
+    # via requests-oauthlib
+pydantic==2.12.5
+    # via garth
+pydantic-core==2.41.5
+    # via pydantic
 python-dateutil==2.9.0.post0
     # via garminexport (setup.py)
-requests==2.32.4
-    # via garminexport (setup.py)
+requests==2.32.5
+    # via
+    #   garminexport (setup.py)
+    #   garth
+    #   requests-oauthlib
+requests-oauthlib==2.0.0
+    # via garth
 six==1.17.0
     # via python-dateutil
-urllib3==2.5.0
+typing-extensions==4.15.0
+    # via
+    #   pydantic
+    #   pydantic-core
+    #   typing-inspection
+typing-inspection==0.4.2
+    # via pydantic
+urllib3==2.6.2
     # via requests

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,17 +24,17 @@ classifiers =
     Natural Language :: English
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
-
+    Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
 
 [options]
 zip_safe = True
 packages =
     garminexport
     garminexport.cli
-python_requires = >=3.9
+python_requires = >=3.10
 install_requires =
     requests>=2.0,<3
     garth>=0.5.19,<0.6.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,7 @@ packages =
 python_requires = >=3.9
 install_requires =
     requests>=2.0,<3
+    garth>=0.5.19,<0.6.0
     python-dateutil~=2.4
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ universal = 1
 
 [metadata]
 name = garminexport
-version = 0.6.0
+version = 0.7.0
 description = Garmin Connect activity exporter and backup tool
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ universal = 1
 
 [metadata]
 name = garminexport
-version = 0.5.0
+version = 0.6.0
 description = Garmin Connect activity exporter and backup tool
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
This PR switches to the Android app authentication flow by relying on [garth](https://github.com/matin/garth).

The ambition is that this will lead to a more robust solution that (hopefully) will stand the test of time better than the approach used thus far.

See https://github.com/petergardfjall/garminexport/issues/123