### PR TITLE
fix oauth2 token refresh bug

### DIFF
--- a/garminexport/authenticator.py
+++ b/garminexport/authenticator.py
@@ -55,7 +55,6 @@ class Authenticator(object):
         self.username = username
         self.password = password
         self.mfa_code_prompt = mfa_code_prompt
-        self.auth_client = garth.Client()
 
     def ensure_authenticated_session(self) -> Session:
         """Returns a Session prepared with authentication headers."""
@@ -91,16 +90,19 @@ class Authenticator(object):
         # Refresh auth token and save in token store.
         log.debug("refreshing oauth2 token (expires in %.1fs) ...",
                   time_to_expiry(token))
-        self.auth_client.refresh_oauth2()
+        auth_client = garth.Client(
+            oauth1_token=self.token_store.get_oauth1_token(),
+            oauth2_token=token)
+        auth_client.refresh_oauth2()
         log.debug("saving refreshed oauth token ...")
-        self._save_tokens(
-            self.auth_client.oauth1_token, self.auth_client.oauth2_token)
-        return self.auth_client.oauth2_token
+        self._save_tokens(auth_client.oauth1_token, auth_client.oauth2_token)
+        return auth_client.oauth2_token
 
     def _acquire_tokens(self) -> (OAuth1Token, OAuth2Token):
         """Perform full login to acquire both OAuth1Token and OAuth2Token."""
         log.debug("acquiring authentication token ...")
-        oauth1_token, oauth2_token = self.auth_client.login(
+        auth_client = garth.Client()
+        oauth1_token, oauth2_token = auth_client.login(
             self.username, self.password, prompt_mfa=self.mfa_code_prompt)
         return oauth1_token, oauth2_token
 

--- a/garminexport/token_store.py
+++ b/garminexport/token_store.py
@@ -28,7 +28,16 @@ class TokenStore(object):
             return False
         return not oauth2_token.refresh_expired
 
+    def get_oauth1_token(self) -> OAuth1Token:
+        """Returns the saved OAuth1Token or throws an exception on failure to
+        do so."""
+        if self.auth_client.oauth1_token is None:
+            self.auth_client.load(self.folder)
+        return self.auth_client.oauth1_token
+
     def get_oauth2_token(self) -> OAuth2Token:
+        """Returns the saved OAuth2Token or throws an exception on failure to
+        do so."""
         if self.auth_client.oauth2_token is None:
             self.auth_client.load(self.folder)
         return self.auth_client.oauth2_token


### PR DESCRIPTION
The `garth.Client` used to refresh an expired oauth2 token needs to make use of an oauth1 token or else we get: `AssertionError: OAuth1 token is required for OAuth2 refresh`.

See https://github.com/petergardfjall/garminexport/pull/126